### PR TITLE
Fix warnings reported by compilation with clang.

### DIFF
--- a/lib/net/linklayer.cpp
+++ b/lib/net/linklayer.cpp
@@ -142,7 +142,7 @@ boolean CLinkLayer::Send (const CIPAddress &rReceiver, const void *pIPPacket, un
 
 	m_pNetDevLayer->Send (pFrameBuffer, nFrameLength);
 
-	delete pFrameBuffer;
+	delete [] pFrameBuffer;
 	pFrameBuffer = 0;
 	
 	return TRUE;

--- a/lib/net/networklayer.cpp
+++ b/lib/net/networklayer.cpp
@@ -201,7 +201,7 @@ boolean CNetworkLayer::Send (const CIPAddress &rReceiver, const void *pPacket, u
 	if (   pOwnIPAddress->IsNull ()
 	    && !rReceiver.IsBroadcast ())
 	{
-		delete pPacketBuffer;
+		delete [] pPacketBuffer;
 		pPacketBuffer = 0;
 
 		return FALSE;
@@ -224,7 +224,7 @@ boolean CNetworkLayer::Send (const CIPAddress &rReceiver, const void *pPacket, u
 		pNextHop = m_pNetConfig->GetDefaultGateway ();
 		if (pNextHop->IsNull ())
 		{
-			delete pPacketBuffer;
+			delete [] pPacketBuffer;
 			pPacketBuffer = 0;
 
 			return FALSE;
@@ -235,7 +235,7 @@ boolean CNetworkLayer::Send (const CIPAddress &rReceiver, const void *pPacket, u
 	assert (pNextHop != 0);
 	boolean bOK = m_pLinkLayer->Send (*pNextHop, pPacketBuffer, nPacketLength);
 	
-	delete pPacketBuffer;
+	delete [] pPacketBuffer;
 	pPacketBuffer = 0;
 
 	return bOK;

--- a/lib/net/udpconnection.cpp
+++ b/lib/net/udpconnection.cpp
@@ -129,7 +129,7 @@ int CUDPConnection::Send (const void *pData, unsigned nLength, int nFlags)
 	assert (m_pNetworkLayer != 0);
 	boolean bOK = m_pNetworkLayer->Send (m_ForeignIP, pPacketBuffer, nPacketLength, IPPROTO_UDP);
 	
-	delete pPacketBuffer;
+	delete [] pPacketBuffer;
 	pPacketBuffer = 0;
 
 	return bOK ? nLength : -1;
@@ -201,7 +201,7 @@ int CUDPConnection::SendTo (const void *pData, unsigned nLength, int nFlags,
 	assert (m_pNetworkLayer != 0);
 	boolean bOK = m_pNetworkLayer->Send (rForeignIP, pPacketBuffer, nPacketLength, IPPROTO_UDP);
 	
-	delete pPacketBuffer;
+	delete [] pPacketBuffer;
 	pPacketBuffer = 0;
 
 	return bOK ? nLength : -1;

--- a/lib/new.cpp
+++ b/lib/new.cpp
@@ -29,12 +29,12 @@ void *operator new[] (unsigned nSize)
 	return malloc (nSize);
 }
 
-void operator delete (void *pBlock)
+void operator delete (void *pBlock) noexcept
 {
 	free (pBlock);
 }
 
-void operator delete[] (void *pBlock)
+void operator delete[] (void *pBlock) noexcept
 {
 	free (pBlock);
 }


### PR DESCRIPTION
I tried to compile circle with clang 3.8.1, and clang warned about some minor C++ problems.
This pull request is supposed to fix some new[]/delete mismatches and the declaration of operator
delete/delete [].