### PR TITLE
Fix another new[]/delete mismatch.

### DIFF
--- a/lib/logger.cpp
+++ b/lib/logger.cpp
@@ -47,7 +47,7 @@ CLogger::~CLogger ()
 {
 	s_pThis = 0;
 
-	delete m_pBuffer;
+	delete [] m_pBuffer;
 	m_pBuffer = 0;
 
 	m_pTarget = 0;


### PR DESCRIPTION
During my experiments with circle I found another new[]/delete mismatch in the CLogger class.

BTW, wouldn't it make sense to replace the allocated CLogger::m_pBuffer pointer with a
member array of size LOGGER_BUFSIZE, as the size is known at compile time anyway?
This would avoid the new/delete for CLogger::m_pBuffer altogether.