### PR TITLE
git-ignore all downloaded files in boot directory

### DIFF
--- a/boot/.gitignore
+++ b/boot/.gitignore
@@ -1,0 +1,3 @@
+/bootcode.bin
+/fixup.dat
+/LICENCE.broadcom

--- a/boot/.gitignore
+++ b/boot/.gitignore
@@ -1,3 +1,4 @@
-/bootcode.bin
-/fixup.dat
-/LICENCE.broadcom
+bootcode.bin
+fixup.dat
+LICENCE.broadcom
+start.elf


### PR DESCRIPTION
As the Raspberry Pi firmware will never be added to the circle repository, I added a corresponding .gitignore file to get a clean unmodified tree even with the downloaded firmware files being present.