### PR TITLE
calloc() must initialize all bits to 0.

### DIFF
--- a/lib/alloc.cpp
+++ b/lib/alloc.cpp
@@ -202,7 +202,13 @@ void *calloc (size_t nBlocks, size_t nSize)
 		return 0;
 	}
 
-	return malloc (nSize);
+	void *pNewBlock = malloc (nSize);
+	if (pNewBlock != 0)
+	{
+		memset (pNewBlock, 0, nSize);
+	}
+
+	return pNewBlock;
 }
 
 void *realloc (void *pBlock, size_t nSize)


### PR DESCRIPTION
See http://pubs.opengroup.org/onlinepubs/009695399/functions/calloc.html:

"The calloc() function shall allocate unused space for an array of nelem elements each of whose size in bytes is elsize. The space shall be initialized to all bits 0."