### PR TITLE
Eclipse support: Flasher.py update

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -102,12 +102,13 @@ clean:
 
 SERIALPORT  ?= /dev/ttyUSB0
 DEFAULTBAUD ?= 115200
+FLASHBAUD ?= 115200
 
 $(TARGET).hex: $(TARGET).img
 	$(PREFIX)objcopy $(TARGET).elf -O ihex $(TARGET).hex
 
 flash: $(TARGET).hex
-	python $(CIRCLEHOME)/tools/flasher.py $(TARGET).hex $(SERIALPORT) $(DEFAULTBAUD)
+	python $(CIRCLEHOME)/tools/flasher.py $(TARGET).hex $(SERIALPORT) $(FLASHBAUD)
 
 monitor:
 	putty -serial $(SERIALPORT) -sercfg $(DEFAULTBAUD)

--- a/tools/bootloader/Makefile
+++ b/tools/bootloader/Makefile
@@ -1,11 +1,11 @@
 -include ../../Config.mk
 
 PREFIX ?= arm-none-eabi
-DEFAULTBAUD ?= 115200
+FLASHBAUD ?= 115200
 
 ARMGNU ?= $(PREFIX)
 
-COPS = -Wall -O2 -nostdlib -nostartfiles -ffreestanding -DDEFAULTBAUD=$(DEFAULTBAUD)
+COPS = -Wall -O2 -nostdlib -nostartfiles -ffreestanding -DDEFAULTBAUD=$(FLASHBAUD)
 
 gcc : kernel.img kernel7.img blinker.hex blinker7.hex
 

--- a/tools/flasher.py
+++ b/tools/flasher.py
@@ -1,21 +1,39 @@
 import serial
+from serial import SerialException
 import struct
 import sys
+from time import sleep
 
+fileaddress = ' '.join(sys.argv[1:2])
+flashport = ' '.join(sys.argv[2:3])
+flashbaud = int(' '.join(sys.argv[3:]))
 
-fileaddress = ' '.join(sys.argv[1:])
-ser = serial.Serial(
-    port='/dev/ttyUSB0',
-    baudrate=115200,
-    parity=serial.PARITY_NONE,
-    stopbits=serial.STOPBITS_ONE,
-    bytesize=serial.EIGHTBITS
-)
-
-print(ser.isOpen())
-F = open(fileaddress,"r")
+try:
+    ser = serial.Serial(
+        port=flashport,
+        baudrate=flashbaud,
+        parity=serial.PARITY_NONE,
+        stopbits=serial.STOPBITS_ONE,
+        bytesize=serial.EIGHTBITS
+    )
+except SerialException:
+    print("ERROR: Serial Port " + flashport + " busy or inexistent!")
+    exit()
+    
+try:
+    F = open(fileaddress,"r")
+except:
+    print("ERROR: Cannot open file " + fileaddress + "\nCheck permissions!")
+    exit()
 data = F.read()
-
-ser.write(data)
-ser.write("g")
+#data = struct.pack(hex, 0x7E, 0xFF, 0x03, 0x00, 0x01, 0x00, 0x02, 0x0A, 0x01, 0xC8,      0x04, 0xD0, 0x01, 0x02, 0x80, 0x00, 0x00, 0x00, 0x00, 0x8E, 0xE7, 0x7E)
+print("Flashing with baudrate of "+ str(flashbaud) + "...")
+try:
+    ser.write(data)
+    ser.write("g")
+except SerialException:
+    print("ERROR: Serial port disconnected.\nCheck connections!")
+    ser.close()
+    exit()
 ser.close()
+print("Completed!\nRunning app...")


### PR DESCRIPTION
->Support for error handling
->Support for different flash baudrate

Rules.mk update
->FLASHBAUD now defines bootloader serial baudrate instead of DEFAULTBAUD
which is used only for normal serial communication when doing make monitor

bootloader/Makefile.mk update
->changed DEFAULTBAUD to FLASHBAUD as above
  