### PR TITLE
make 'make' command externally controllable

### DIFF
--- a/addon/vc4/interface/makeall
+++ b/addon/vc4/interface/makeall
@@ -1,17 +1,19 @@
 #!/bin/bash
 
+make="${MAKE:-make}"
+
 cd vcos
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd vmcs_host
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd khronos
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd bcm_host
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..

--- a/addon/vc4/makeall
+++ b/addon/vc4/makeall
@@ -1,14 +1,16 @@
 #!/bin/bash
 
+make="${MAKE:-make}"
+
 cd vchiq
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd sound
-make $1 $2 || exit
+$make $1 $2 || exit
 
 cd sample
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd ..

--- a/app/makeall
+++ b/app/makeall
@@ -1,23 +1,25 @@
 #!/bin/bash
 
+make="${MAKE:-make}"
+
 cd lib
 
 cd template
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 # TODO: Add new libs here
 #cd subdir
-#make $1 $2 || exit
+#$make $1 $2 || exit
 #cd ..
 
 cd ..
 
 cd template
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 # TODO: Add new apps here
 #cd subdir
-#make $1 $2 || exit
+#$make $1 $2 || exit
 #cd ..

--- a/makeall
+++ b/makeall
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+make="${MAKE:-make}"
+
 makesample=true
 if [[ $1 == "--nosample" ]]
 then
@@ -8,35 +10,35 @@ then
 fi
 
 cd lib
-make $1 $2 || exit
+$make $1 $2 || exit
 
 cd usb
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd input
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd fs
-make $1 $2 || exit
+$make $1 $2 || exit
 
 cd fat
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd ..
 
 cd sched
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd net
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd bt
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..
 
 cd ..

--- a/sample/makeall
+++ b/sample/makeall
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+make="${MAKE:-make}"
+
 for sample in [0-9][0-9]-* ;  do
 	echo $sample:
 	cd $sample
-	make $1 $2 || exit
+	$make $1 $2 || exit
 	cd ..
 done

--- a/sample/makelatest
+++ b/sample/makelatest
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+make="${MAKE:-make}"
+
 cd `ls -dr [0-9][0-9]-* | head -n 1`
-make $1 $2 || exit
+$make $1 $2 || exit
 cd ..


### PR DESCRIPTION
This allows for this kind of compile command:
env MAKE="gmake" ./makeall
(useful on mac, since system make version is < 4)

or even better:
env MAKE="gmake -j" ./makeall
for fast compile