### PR TITLE
Flasher: Mac hangs on serial close

### DIFF
--- a/tools/flasher.py
+++ b/tools/flasher.py
@@ -59,8 +59,14 @@ try:
 except Exception:
     print("ERROR: Serial port disconnected. Check connections!")
     F.close()
+    time.sleep(0.2)
+    ser.flush()
+    time.sleep(0.2)
     ser.close()
     exit()
 
 F.close()
+time.sleep(0.2)
+ser.flush()
+time.sleep(0.2)
 ser.close()

--- a/tools/reboottool.py
+++ b/tools/reboottool.py
@@ -38,4 +38,7 @@ time.sleep(4)
 
 print("Completed!")
 
+time.sleep(0.2)
+ser.flush()
+time.sleep(0.2)
 ser.close()


### PR DESCRIPTION
Solution to this problem was found here after much digging around: https://github.com/bitlogik/HomeTicker/commit/c6d2e3d12fb03b57163fd8b7b64af9805fa2e043#diff-65dfa4e1cf447aae2e619e790e1206f1. In essence: the serial device must be explicitly flushed on Mac to allow close to be called, otherwise the process hangs forever and requires a reboot.