### PR TITLE
boot: Download "cutdown" start.elf variants

### DIFF
--- a/boot/Makefile
+++ b/boot/Makefile
@@ -18,9 +18,13 @@ firmware: clean
 	wget -q -O COPYING.linux $(BASEURL)/COPYING.linux?raw=true
 	wget -q -O bootcode.bin $(BASEURL)/bootcode.bin?raw=true
 	wget -q -O fixup.dat $(BASEURL)/fixup.dat?raw=true
+	wget -q -O fixup_cd.dat $(BASEURL)/fixup_cd.dat?raw=true
 	wget -q -O start.elf $(BASEURL)/start.elf?raw=true
+	wget -q -O start_cd.elf $(BASEURL)/start_cd.elf?raw=true
 	wget -q -O fixup4.dat $(BASEURL)/fixup4.dat?raw=true
+	wget -q -O fixup4cd.dat $(BASEURL)/fixup4cd.dat?raw=true
 	wget -q -O start4.elf $(BASEURL)/start4.elf?raw=true
+	wget -q -O start4cd.elf $(BASEURL)/start4cd.elf?raw=true
 	wget -q -O bcm2711-rpi-4-b.dtb $(BASEURL)/bcm2711-rpi-4-b.dtb?raw=true
 
 all: firmware bootloader


### PR DESCRIPTION
The Raspberry Pi firmware repository contains "cutdown" versions of
start.elf/start4.elf (start_cd.elf/start4cd.elf) that don't include
codec/3D-related code.

These versions may be useful for those looking to reduce the Raspberry
Pi boot time to an absolute minimum, as they are smaller and quicker to
load.