### PR TITLE
Prevent garbage collection of .init_array sections

### DIFF
--- a/circle.ld
+++ b/circle.ld
@@ -23,7 +23,7 @@ SECTIONS
 	.init_array : {
 		__init_start = .;
 
-		*(.init_array*)
+		KEEP(*(.init_array*))
 
 		__init_end = .;
 	}


### PR DESCRIPTION
Hi Rene!

One of my users reported USB MIDI being broken since my project updated to Circle Step 43 (dwhinham/mt32-pi#40).
I noticed that the cause was that my USB MIDI devices were being named `usbmidi0` instead of the expected `usbmidi1`.

I've tracked this down to my use of `GC_SECTIONS` to reduce the kernel size.

When `GC_SECTIONS` is enabled, [the static constructors for your new `CNumberPool` instances that start numbering at 1](https://github.com/rsta2/circle/blob/4394f8adff299781e3386482acba2cf91e784ee4/lib/usb/usbmidi.cpp#L38) aren't being called because the `.init_array` sections get garbage collected - the linker thinks they're unreferenced. This results in the numbering starting from 0.

With this patch, a simple `KEEP()` statement in the linker script prevents static constructor calls from being garbage collected, solving the problem.

You should be able to reproduce this problem (and confirm the fix) by compiling `miniorgan` with `GC_SECTIONS` enabled.

Thanks! 🙂
