### PR TITLE
support for USB mouse HID report protocol

### DIFF
--- a/include/circle/input/mouse.h
+++ b/include/circle/input/mouse.h
@@ -28,7 +28,7 @@
 #define MOUSE_DISPLACEMENT_MIN	-127
 #define MOUSE_DISPLACEMENT_MAX	127
 
-typedef void TMouseStatusHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY);
+typedef void TMouseStatusHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove);
 
 class CMouseDevice : public CDevice	/// Generic mouse interface device ("mouse1")
 {
@@ -65,7 +65,7 @@ public:
 
 public:
 	/// \warning Do not call this from application!
-	void ReportHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY);
+	void ReportHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove);
 
 private:
 	CMouseBehaviour m_Behaviour;

--- a/include/circle/input/mouse.h
+++ b/include/circle/input/mouse.h
@@ -33,7 +33,10 @@ typedef void TMouseStatusHandler (unsigned nButtons, int nDisplacementX, int nDi
 class CMouseDevice : public CDevice	/// Generic mouse interface device ("mouse1")
 {
 public:
-	CMouseDevice (void);
+	/// \brief Construct a mouse device instance
+	/// \param nButtons Number of buttons
+	/// \param bHasWheel Wheel presence
+	CMouseDevice (unsigned nButtons, boolean bHasWheel = FALSE);
 	~CMouseDevice (void);
 
 	/// \brief Setup mouse device in cooked mode
@@ -63,6 +66,12 @@ public:
 	/// \param pStatusHandler Pointer to the mouse status handler
 	void RegisterStatusHandler (TMouseStatusHandler *pStatusHandler);
 
+	/// \return Number of supported mouse buttons
+	unsigned GetButtonCount (void) const;
+
+	/// \return Does the mouse support a mouse wheel?
+	boolean HasWheel (void) const;
+
 public:
 	/// \warning Do not call this from application!
 	void ReportHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove);
@@ -74,6 +83,9 @@ private:
 
 	unsigned m_nDeviceNumber;
 	static CNumberPool s_DeviceNumberPool;
+
+	unsigned m_nButtons;
+	boolean m_bHasWheel;
 };
 
 #endif

--- a/include/circle/input/mousebehaviour.h
+++ b/include/circle/input/mousebehaviour.h
@@ -29,7 +29,7 @@ enum TMouseEvent
 	MouseEventMouseUp,
 	//MouseEventClick,
 	//MouseEventDoubleClick,
-    MouseEventMouseWheel,
+	MouseEventMouseWheel,
 	MouseEventUnknown
 };
 

--- a/include/circle/input/mousebehaviour.h
+++ b/include/circle/input/mousebehaviour.h
@@ -29,6 +29,7 @@ enum TMouseEvent
 	MouseEventMouseUp,
 	//MouseEventClick,
 	//MouseEventDoubleClick,
+    MouseEventMouseWheel,
 	MouseEventUnknown
 };
 
@@ -36,7 +37,7 @@ enum TMouseEvent
 #define MOUSE_BUTTON_RIGHT	(1 << 1)
 #define MOUSE_BUTTON_MIDDLE	(1 << 2)
 
-typedef void TMouseEventHandler (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY);
+typedef void TMouseEventHandler (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY, int nWheelMove);
 
 class CMouseBehaviour
 {
@@ -54,7 +55,7 @@ public:
 	void UpdateCursor (void);	// call this frequently from TASK_LEVEL
 
 public:
-	void MouseStatusChanged (unsigned nButtons, int nDisplacementX, int nDisplacementY);
+	void MouseStatusChanged (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove);
 
 private:
 	static boolean SetCursorState (unsigned nPosX, unsigned nPosY, boolean bVisible);

--- a/include/circle/usb/usbmouse.h
+++ b/include/circle/usb/usbmouse.h
@@ -24,6 +24,30 @@
 #include <circle/input/mouse.h>
 #include <circle/types.h>
 
+enum TMouseReportType {
+    MouseItemNone,
+    MouseItemButtons,
+    MouseItemXAxis,
+    MouseItemYAxis,
+    MouseItemWheel
+};
+
+struct TMouseReportItem {
+    unsigned type;
+    unsigned count;
+    unsigned offset;
+};
+#define MAX_ITEMS    16
+
+struct TMouseReport
+{
+    unsigned id;
+    unsigned size;
+
+    unsigned nItems;
+    TMouseReportItem items[MAX_ITEMS];
+};
+
 class CUSBMouseDevice : public CUSBHIDDevice
 {
 public:
@@ -34,12 +58,17 @@ public:
 
 private:
 	void ReportHandler (const u8 *pReport, unsigned nReportSize);
+    void DecodeReport (void);
+    u32 ExtractUnsigned (const void *buffer, u32 offset, u32 length);
+	s32 ExtractSigned (const void *buffer, u32 offset, u32 length);
 
 private:
 	CMouseDevice *m_pMouseDevice;
 
 	u8 *m_pHIDReportDescriptor;
 	u16 m_usReportDescriptorLength;
+
+    TMouseReport m_ReportItems;
 };
 
 #endif

--- a/include/circle/usb/usbmouse.h
+++ b/include/circle/usb/usbmouse.h
@@ -24,28 +24,27 @@
 #include <circle/input/mouse.h>
 #include <circle/types.h>
 
-enum TMouseReportType {
-	MouseItemNone,
+enum TMouseReportType
+{
 	MouseItemButtons,
 	MouseItemXAxis,
 	MouseItemYAxis,
-	MouseItemWheel
+	MouseItemWheel,
+
+	MouseItemCount
 };
 
-struct TMouseReportItem {
-	unsigned type;
-	unsigned count;
-	unsigned offset;
+struct TMouseReportItem
+{
+	unsigned bitSize;
+	unsigned bitOffset;
 };
-#define MAX_MOUSE_REPORT_ITEMS    16
 
 struct TMouseReport
 {
 	unsigned id;
-	unsigned size;
-
-	unsigned nItems;
-	TMouseReportItem items[MAX_MOUSE_REPORT_ITEMS];
+	unsigned byteSize;
+	TMouseReportItem items[MouseItemCount];
 };
 
 class CUSBMouseDevice : public CUSBHIDDevice
@@ -58,7 +57,7 @@ public:
 
 private:
 	void ReportHandler (const u8 *pReport, unsigned nReportSize);
-	void DecodeReport (unsigned *nButtons, boolean *bHasWheel);
+	void DecodeReport (void);
 	u32 ExtractUnsigned (const void *buffer, u32 offset, u32 length);
 	s32 ExtractSigned (const void *buffer, u32 offset, u32 length);
 

--- a/include/circle/usb/usbmouse.h
+++ b/include/circle/usb/usbmouse.h
@@ -58,7 +58,7 @@ public:
 
 private:
 	void ReportHandler (const u8 *pReport, unsigned nReportSize);
-	void DecodeReport (void);
+	void DecodeReport (unsigned *nButtons, boolean *bHasWheel);
 	u32 ExtractUnsigned (const void *buffer, u32 offset, u32 length);
 	s32 ExtractSigned (const void *buffer, u32 offset, u32 length);
 

--- a/include/circle/usb/usbmouse.h
+++ b/include/circle/usb/usbmouse.h
@@ -37,7 +37,7 @@ struct TMouseReportItem {
 	unsigned count;
 	unsigned offset;
 };
-#define MAX_ITEMS    16
+#define MAX_MOUSE_REPORT_ITEMS    16
 
 struct TMouseReport
 {
@@ -45,7 +45,7 @@ struct TMouseReport
 	unsigned size;
 
 	unsigned nItems;
-	TMouseReportItem items[MAX_ITEMS];
+	TMouseReportItem items[MAX_MOUSE_REPORT_ITEMS];
 };
 
 class CUSBMouseDevice : public CUSBHIDDevice
@@ -68,7 +68,7 @@ private:
 	u8 *m_pHIDReportDescriptor;
 	u16 m_usReportDescriptorLength;
 
-	TMouseReport m_ReportItems;
+	TMouseReport m_MouseReport;
 };
 
 #endif

--- a/include/circle/usb/usbmouse.h
+++ b/include/circle/usb/usbmouse.h
@@ -25,27 +25,27 @@
 #include <circle/types.h>
 
 enum TMouseReportType {
-    MouseItemNone,
-    MouseItemButtons,
-    MouseItemXAxis,
-    MouseItemYAxis,
-    MouseItemWheel
+	MouseItemNone,
+	MouseItemButtons,
+	MouseItemXAxis,
+	MouseItemYAxis,
+	MouseItemWheel
 };
 
 struct TMouseReportItem {
-    unsigned type;
-    unsigned count;
-    unsigned offset;
+	unsigned type;
+	unsigned count;
+	unsigned offset;
 };
 #define MAX_ITEMS    16
 
 struct TMouseReport
 {
-    unsigned id;
-    unsigned size;
+	unsigned id;
+	unsigned size;
 
-    unsigned nItems;
-    TMouseReportItem items[MAX_ITEMS];
+	unsigned nItems;
+	TMouseReportItem items[MAX_ITEMS];
 };
 
 class CUSBMouseDevice : public CUSBHIDDevice
@@ -58,8 +58,8 @@ public:
 
 private:
 	void ReportHandler (const u8 *pReport, unsigned nReportSize);
-    void DecodeReport (void);
-    u32 ExtractUnsigned (const void *buffer, u32 offset, u32 length);
+	void DecodeReport (void);
+	u32 ExtractUnsigned (const void *buffer, u32 offset, u32 length);
 	s32 ExtractSigned (const void *buffer, u32 offset, u32 length);
 
 private:
@@ -68,7 +68,7 @@ private:
 	u8 *m_pHIDReportDescriptor;
 	u16 m_usReportDescriptorLength;
 
-    TMouseReport m_ReportItems;
+	TMouseReport m_ReportItems;
 };
 
 #endif

--- a/lib/input/mouse.cpp
+++ b/lib/input/mouse.cpp
@@ -77,12 +77,12 @@ void CMouseDevice::RegisterStatusHandler (TMouseStatusHandler *pStatusHandler)
 	assert (m_pStatusHandler != 0);
 }
 
-void CMouseDevice::ReportHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY)
+void CMouseDevice::ReportHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove)
 {
-	m_Behaviour.MouseStatusChanged (nButtons, nDisplacementX, nDisplacementY);
+	m_Behaviour.MouseStatusChanged (nButtons, nDisplacementX, nDisplacementY, nWheelMove);
 
 	if (m_pStatusHandler != 0)
 	{
-		(*m_pStatusHandler) (nButtons, nDisplacementX, nDisplacementY);
+		(*m_pStatusHandler) (nButtons, nDisplacementX, nDisplacementY, nWheelMove);
 	}
 }

--- a/lib/input/mouse.cpp
+++ b/lib/input/mouse.cpp
@@ -26,9 +26,11 @@ CNumberPool CMouseDevice::s_DeviceNumberPool (1);
 static const char FromMouse[] = "mouse";
 static const char DevicePrefix[] = "mouse";
 
-CMouseDevice::CMouseDevice (void)
+CMouseDevice::CMouseDevice (unsigned nButtons, boolean bHasWheel)
 :	m_pStatusHandler (0),
-	m_nDeviceNumber (s_DeviceNumberPool.AllocateNumber (TRUE, FromMouse))
+	m_nDeviceNumber (s_DeviceNumberPool.AllocateNumber (TRUE, FromMouse)),
+	m_nButtons (nButtons),
+	m_bHasWheel (bHasWheel)
 {
 	CDeviceNameService::Get ()->AddDevice (DevicePrefix, m_nDeviceNumber, this, FALSE);
 }
@@ -85,4 +87,14 @@ void CMouseDevice::ReportHandler (unsigned nButtons, int nDisplacementX, int nDi
 	{
 		(*m_pStatusHandler) (nButtons, nDisplacementX, nDisplacementY, nWheelMove);
 	}
+}
+
+unsigned CMouseDevice::GetButtonCount (void) const
+{
+	return m_nButtons;
+}
+
+boolean CMouseDevice::HasWheel (void) const
+{
+	return m_bHasWheel;
 }

--- a/lib/input/mousebehaviour.cpp
+++ b/lib/input/mousebehaviour.cpp
@@ -161,7 +161,7 @@ void CMouseBehaviour::UpdateCursor (void)
 	}
 }
 
-void CMouseBehaviour::MouseStatusChanged (unsigned nButtons, int nDisplacementX, int nDisplacementY)
+void CMouseBehaviour::MouseStatusChanged (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove)
 {
 	if (   m_nScreenWidth == 0		// not setup?
 	    || m_nScreenHeight == 0)
@@ -194,7 +194,7 @@ void CMouseBehaviour::MouseStatusChanged (unsigned nButtons, int nDisplacementX,
 
 		if (m_pEventHandler != 0)
 		{
-			(*m_pEventHandler) (MouseEventMouseMove, nButtons, m_nPosX, m_nPosY);
+			(*m_pEventHandler) (MouseEventMouseMove, nButtons, m_nPosX, m_nPosY, nWheelMove);
 		}
 	}
 
@@ -208,15 +208,22 @@ void CMouseBehaviour::MouseStatusChanged (unsigned nButtons, int nDisplacementX,
 			if (   !(m_nButtons & nMask)
 			    &&  (nButtons & nMask))
 			{
-				(*m_pEventHandler) (MouseEventMouseDown, nMask, m_nPosX, m_nPosY);
+				(*m_pEventHandler) (MouseEventMouseDown, nMask, m_nPosX, m_nPosY, nWheelMove);
 			}
 			else if (   (m_nButtons & nMask)
 				 && !(nButtons & nMask))
 			{
-				(*m_pEventHandler) (MouseEventMouseUp, nMask, m_nPosX, m_nPosY);
+				(*m_pEventHandler) (MouseEventMouseUp, nMask, m_nPosX, m_nPosY, nWheelMove);
 			}
 		}
 	}
+
+    if (nWheelMove != 0) {
+        if (m_pEventHandler != 0)
+		{
+			(*m_pEventHandler) (MouseEventMouseWheel, nButtons, m_nPosX, m_nPosY, nWheelMove);
+		}
+    }
 
 	m_nButtons = nButtons;
 }

--- a/lib/input/mousebehaviour.cpp
+++ b/lib/input/mousebehaviour.cpp
@@ -218,12 +218,12 @@ void CMouseBehaviour::MouseStatusChanged (unsigned nButtons, int nDisplacementX,
 		}
 	}
 
-    if (nWheelMove != 0) {
-        if (m_pEventHandler != 0)
+	if (nWheelMove != 0) {
+		if (m_pEventHandler != 0)
 		{
 			(*m_pEventHandler) (MouseEventMouseWheel, nButtons, m_nPosX, m_nPosY, nWheelMove);
 		}
-    }
+	}
 
 	m_nButtons = nButtons;
 }

--- a/lib/usb/usbgamepadps4.cpp
+++ b/lib/usb/usbgamepadps4.cpp
@@ -159,7 +159,7 @@ boolean CUSBGamePadPS4Device::Configure (void)
 
 	if (s_bTouchpadEnabled)
 	{
-		m_pMouseDevice = new CMouseDevice;
+		m_pMouseDevice = new CMouseDevice(1);
 		assert (m_pMouseDevice != 0);
 	}
 

--- a/lib/usb/usbgamepadps4.cpp
+++ b/lib/usb/usbgamepadps4.cpp
@@ -346,7 +346,7 @@ void CUSBGamePadPS4Device::HandleTouchpad (const u8 *pReportBuffer)
 			assert (m_pMouseDevice != 0);
 			m_pMouseDevice->ReportHandler (  m_Touchpad.bButtonPressed
 						       ? MOUSE_BUTTON_LEFT : 0,
-						       nDisplacementX, nDisplacementY);
+						       nDisplacementX, nDisplacementY, 0);
 
 			bButtonChanged = FALSE;
 			nDisplacementX = 0;

--- a/lib/usb/usbhiddevice.cpp
+++ b/lib/usb/usbhiddevice.cpp
@@ -110,7 +110,7 @@ boolean CUSBHIDDevice::Configure (unsigned nMaxReportSize)
 	{
 		if (GetHost ()->ControlMessage (GetEndpoint0 (),
 						REQUEST_OUT | REQUEST_CLASS | REQUEST_TO_INTERFACE,
-						SET_PROTOCOL, BOOT_PROTOCOL,
+						SET_PROTOCOL, REPORT_PROTOCOL/*BOOT_PROTOCOL*/,
 						GetInterfaceNumber (), 0, 0) < 0)
 		{
 			CLogger::Get ()->Write (FromUSBHID, LogError, "Cannot set boot protocol");

--- a/lib/usb/usbhiddevice.cpp
+++ b/lib/usb/usbhiddevice.cpp
@@ -110,7 +110,8 @@ boolean CUSBHIDDevice::Configure (unsigned nMaxReportSize)
 	{
 		if (GetHost ()->ControlMessage (GetEndpoint0 (),
 						REQUEST_OUT | REQUEST_CLASS | REQUEST_TO_INTERFACE,
-						SET_PROTOCOL, REPORT_PROTOCOL/*BOOT_PROTOCOL*/,
+						SET_PROTOCOL,   GetInterfaceProtocol () == 2
+							      ? REPORT_PROTOCOL : BOOT_PROTOCOL,
 						GetInterfaceNumber (), 0, 0) < 0)
 		{
 			CLogger::Get ()->Write (FromUSBHID, LogError, "Cannot set boot protocol");

--- a/lib/usb/usbmouse.cpp
+++ b/lib/usb/usbmouse.cpp
@@ -3,6 +3,7 @@
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
 // Copyright (C) 2014-2018  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2020  H. Kocevar <hinxx@protonmail.com>
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/lib/usb/usbmouse.cpp
+++ b/lib/usb/usbmouse.cpp
@@ -221,6 +221,7 @@ void CUSBMouseDevice::DecodeReport (unsigned *nButtons, boolean *bHasWheel)
 	u32 itemIndex = 0;
 	u32 reportIndex = 0;
 	boolean parse = FALSE;
+	boolean foundMouseUsage = FALSE;
 
 	assert (m_pHIDReportDescriptor != 0);
 	s8 *pHIDReportDescriptor = (s8 *) m_pHIDReportDescriptor;
@@ -265,19 +266,27 @@ void CUSBMouseDevice::DecodeReport (unsigned *nButtons, boolean *bHasWheel)
 			break;
 		case HID_USAGE:
 			if (arg == HID_USAGE_MOUSE)
-				parse = TRUE;
+				foundMouseUsage = TRUE;
+			break;
+		case HID_REPORT_ID:
+			if (foundMouseUsage) {
+				if (id == 0) {
+					id = arg;
+					offset += 8;
+					parse = TRUE;
+				} else {
+					if ((u32)arg != id) {
+						parse = FALSE;
+					} else {
+						parse = TRUE;
+					}
+				}
+			}
 			break;
 		}
 
 		if (! parse)
 			continue;
-
-		if ((item & 0xFC) == HID_REPORT_ID)
-		{
-			assert(id == 0);
-			id = arg;
-			offset = 8;
-		}
 
 		switch(item & 0xFC)
 		{

--- a/lib/usb/usbmouse.cpp
+++ b/lib/usb/usbmouse.cpp
@@ -127,9 +127,17 @@ void CUSBMouseDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)
 					break;
 				case MouseItemXAxis:
 					xMove = ExtractSigned(pReport, item->offset, item->count);
+					if (xMove > 127)
+						xMove = 127;
+					if (xMove < -127)
+						xMove = -127;
 					break;
 				case MouseItemYAxis:
 					yMove = ExtractSigned(pReport, item->offset, item->count);
+					if (yMove > 127)
+						yMove = 127;
+					if (yMove < -127)
+						yMove = -127;
 					break;
 				case MouseItemWheel:
 					wheelMove = ExtractSigned(pReport, item->offset, item->count);

--- a/lib/usb/usbmouse.cpp
+++ b/lib/usb/usbmouse.cpp
@@ -88,12 +88,12 @@ boolean CUSBMouseDevice::Configure (void)
 	DecodeReport ();
 
 	// ignoring unsupported HID interface
-	if (m_ReportItems.nItems == 0)
+	if (m_MouseReport.nItems == 0)
 	{
 		return FALSE;
 	}
 
-	if (!CUSBHIDDevice::Configure (m_ReportItems.size))
+	if (!CUSBHIDDevice::Configure (m_MouseReport.size))
 	{
 		CLogger::Get ()->Write (FromUSBMouse, LogError, "Cannot configure HID device");
 
@@ -109,7 +109,7 @@ boolean CUSBMouseDevice::Configure (void)
 void CUSBMouseDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)
 {
 	if (   pReport != 0
-	    && nReportSize == m_ReportItems.size)
+	    && nReportSize == m_MouseReport.size)
 	{
 		if (m_pMouseDevice != 0)
 		{
@@ -117,9 +117,9 @@ void CUSBMouseDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)
 			s32 xMove = 0;
 			s32 yMove = 0;
 			s32 wheelMove = 0;
-			for (u32 index = 0; index < m_ReportItems.nItems; index++)
+			for (u32 index = 0; index < m_MouseReport.nItems; index++)
 			{
-				TMouseReportItem *item = &m_ReportItems.items[index];
+				TMouseReportItem *item = &m_MouseReport.items[index];
 				switch (item->type)
 				{
 				case MouseItemButtons:
@@ -275,7 +275,7 @@ void CUSBMouseDevice::DecodeReport ()
 			switch(arg)
 			{
 			case HID_USAGE_PAGE_BUTTONS:
-				m_ReportItems.items[itemIndex].type = MouseItemButtons;
+				m_MouseReport.items[itemIndex].type = MouseItemButtons;
 				itemIndex++;
 				break;
 			}
@@ -284,15 +284,15 @@ void CUSBMouseDevice::DecodeReport ()
 			switch(arg)
 			{
 			case HID_USAGE_X:
-				m_ReportItems.items[itemIndex].type = MouseItemXAxis;
+				m_MouseReport.items[itemIndex].type = MouseItemXAxis;
 				itemIndex++;
 				break;
 			case HID_USAGE_Y:
-				m_ReportItems.items[itemIndex].type = MouseItemYAxis;
+				m_MouseReport.items[itemIndex].type = MouseItemYAxis;
 				itemIndex++;
 				break;
 			case HID_USAGE_WHEEL:
-				m_ReportItems.items[itemIndex].type = MouseItemWheel;
+				m_MouseReport.items[itemIndex].type = MouseItemWheel;
 				itemIndex++;
 				break;
 			}
@@ -309,7 +309,7 @@ void CUSBMouseDevice::DecodeReport ()
 				u32 tmp = offset;
 				while (reportIndex < itemIndex)
 				{
-					TMouseReportItem *item = &m_ReportItems.items[reportIndex];
+					TMouseReportItem *item = &m_MouseReport.items[reportIndex];
 					switch (item->type)
 					{
 					case MouseItemButtons:
@@ -333,7 +333,7 @@ void CUSBMouseDevice::DecodeReport ()
 		}
 	}
 
-	m_ReportItems.id = id;
-	m_ReportItems.size = (offset + 7) / 8;
-	m_ReportItems.nItems = itemIndex;
+	m_MouseReport.id = id;
+	m_MouseReport.size = (offset + 7) / 8;
+	m_MouseReport.nItems = itemIndex;
 }

--- a/lib/usb/usbmouse.cpp
+++ b/lib/usb/usbmouse.cpp
@@ -20,14 +20,65 @@
 #include <circle/usb/usbmouse.h>
 #include <circle/usb/usbhid.h>
 #include <circle/logger.h>
+#include <circle/debug.h>
 #include <assert.h>
 
-#define REPORT_SIZE	3
+// HID Report Items from HID 1.11 Section 6.2.2
+#define HID_USAGE_PAGE      0x04
+#define HID_USAGE           0x08
+#define HID_COLLECTION      0xA0
+#define HID_END_COLLECTION  0xC0
+#define HID_REPORT_COUNT    0x94
+#define HID_REPORT_SIZE     0x74
+#define HID_USAGE_MIN       0x18
+#define HID_USAGE_MAX       0x28
+#define HID_LOGICAL_MIN     0x14
+#define HID_LOGICAL_MAX     0x24
+#define HID_PHYSICAL_MIN    0x34
+#define HID_PHYSICAL_MAX    0x44
+#define HID_INPUT           0x80
+#define HID_REPORT_ID       0x84
+#define HID_OUTPUT          0x90
+
+// HID Report Usage Pages from HID Usage Tables 1.12 Section 3, Table 1
+#define HID_USAGE_PAGE_GENERIC_DESKTOP 0x01
+#define HID_USAGE_PAGE_KEY_CODES       0x07
+#define HID_USAGE_PAGE_LEDS            0x08
+#define HID_USAGE_PAGE_BUTTONS         0x09
+
+// HID Report Usages from HID Usage Tables 1.12 Section 4, Table 6
+#define HID_USAGE_POINTER   0x01
+#define HID_USAGE_MOUSE     0x02
+#define HID_USAGE_JOYSTICK  0x04
+#define HID_USAGE_GAMEPAD   0x05
+#define HID_USAGE_KEYBOARD  0x06
+#define HID_USAGE_X         0x30
+#define HID_USAGE_Y         0x31
+#define HID_USAGE_Z         0x32
+#define HID_USAGE_RX        0x33
+#define HID_USAGE_RY        0x34
+#define HID_USAGE_RZ        0x35
+#define HID_USAGE_SLIDER    0x36
+#define HID_USAGE_WHEEL     0x38
+#define HID_USAGE_HATSWITCH 0x39
+
+// HID Report Collection Types from HID 1.12 6.2.2.6
+#define HID_COLLECTION_PHYSICAL    0
+#define HID_COLLECTION_APPLICATION 1
+
+// HID Input/Output/Feature Item Data (attributes) from HID 1.11 6.2.2.5
+#define HID_ITEM_CONSTANT 0x1
+#define HID_ITEM_VARIABLE 0x2
+#define HID_ITEM_RELATIVE 0x4
+
+// in boot protocol 3 bytes are received, in report protocol 5 bytes are received
+//#define REPORT_SIZE 3
+//#define REPORT_SIZE 5
 
 static const char FromUSBMouse[] = "umouse";
 
 CUSBMouseDevice::CUSBMouseDevice (CUSBFunction *pFunction)
-:	CUSBHIDDevice (pFunction, REPORT_SIZE),
+:	CUSBHIDDevice (pFunction),
 	m_pMouseDevice (0),
 	m_pHIDReportDescriptor (0)
 {
@@ -67,8 +118,18 @@ boolean CUSBMouseDevice::Configure (void)
 
 		return FALSE;
 	}
+    CLogger::Get ()->Write (FromUSBMouse, LogDebug, "Report descriptor");
+    debug_hexdump (m_pHIDReportDescriptor, m_usReportDescriptorLength, FromUSBMouse);
 
-	if (!CUSBHIDDevice::Configure ())
+	DecodeReport ();
+
+	// ignoring unsupported HID interface
+	if (m_ReportItems.nItems == 0)
+	{
+		return FALSE;
+	}
+
+	if (!CUSBHIDDevice::Configure (m_ReportItems.size))
 	{
 		CLogger::Get ()->Write (FromUSBMouse, LogError, "Cannot configure HID device");
 
@@ -83,29 +144,265 @@ boolean CUSBMouseDevice::Configure (void)
 
 void CUSBMouseDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)
 {
-	if (   pReport != 0
-	    && nReportSize == REPORT_SIZE)
+//    debug_hexdump (pReport, nReportSize, FromUSBMouse);
+    if (   pReport != 0
+	    && nReportSize == m_ReportItems.size)
 	{
-		u8 ucHIDButtons = pReport[0];
+        // in boot protocol the 3 bytes are:
+        // 0   1 - left button, 2 - right button, 4 - middle button
+        // 1   X displacement (+/- 127 max)
+        // 2   Y displacement (+/- 127 max)
+        // in report protocol the 5 bytes are:
+        // 0   report ID (from report descriptor)
+        // 1   1 - left button, 2 - right button, 4 - middle button
+        // 2   X displacement (+/- 127 max)
+        // 3   Y displacement (+/- 127 max)
+        // 4   1 - wheel up, -1 wheel down
 
-		unsigned nButtons = 0;
-		if (ucHIDButtons & USBHID_BUTTON1)
-		{
-			nButtons |= MOUSE_BUTTON_LEFT;
-		}
-		if (ucHIDButtons & USBHID_BUTTON2)
-		{
-			nButtons |= MOUSE_BUTTON_RIGHT;
-		}
-		if (ucHIDButtons & USBHID_BUTTON3)
-		{
-			nButtons |= MOUSE_BUTTON_MIDDLE;
-		}
+        if (m_pMouseDevice != 0)
+        {
+            u32 ucHIDButtons = 0;
+            s32 xMove = 0;
+            s32 yMove = 0;
+            s32 wheelMove = 0;
+            for (u32 index = 0; index < m_ReportItems.nItems; index++) {
+                TMouseReportItem *item = &m_ReportItems.items[index];
+                switch (item->type) {
+                case MouseItemButtons:
+                    ucHIDButtons = ExtractUnsigned(pReport, item->offset, item->count);
+                    break;
+                case MouseItemXAxis:
+                    xMove = ExtractSigned(pReport, item->offset, item->count);
+                    break;
+                case MouseItemYAxis:
+                    yMove = ExtractSigned(pReport, item->offset, item->count);
+                    break;
+                case MouseItemWheel:
+                    wheelMove = ExtractSigned(pReport, item->offset, item->count);
+                    break;
+                }
+            }
 
-		if (m_pMouseDevice != 0)
-		{
-			m_pMouseDevice->ReportHandler (nButtons, (char) pReport[1],
-						       (char) pReport[2]);
+            u32 nButtons = 0;
+            if (ucHIDButtons & USBHID_BUTTON1)
+            {
+                nButtons |= MOUSE_BUTTON_LEFT;
+            }
+            if (ucHIDButtons & USBHID_BUTTON2)
+            {
+                nButtons |= MOUSE_BUTTON_RIGHT;
+            }
+            if (ucHIDButtons & USBHID_BUTTON3)
+            {
+                nButtons |= MOUSE_BUTTON_MIDDLE;
+            }
+
+            //CLogger::Get ()->Write (FromUSBMouse, LogDebug, "2: %02X %2d %3d %3d %3d", pReport[0], nButtons, xMove, yMove, wheelMove);
+            m_pMouseDevice->ReportHandler (nButtons, xMove, yMove, wheelMove);
 		}
 	}
+}
+
+u32 CUSBMouseDevice::ExtractUnsigned(const void *buffer, u32 offset, u32 length) {
+    assert(buffer != 0);
+    assert(length <= 32);
+
+    u8 *bits = (u8 *)buffer;
+    unsigned shift = offset % 8;
+    offset = offset / 8;
+    bits = bits + offset;
+    unsigned number = *(unsigned *)bits;
+    offset = shift;
+
+    unsigned result = 0;
+    if (length > 24) {
+        result = (((1 << 24) - 1) & (number >> offset));
+        bits = bits + 3;
+        number = *(unsigned *)bits;
+        length = length - 24;
+        unsigned result2 = (((1 << length) - 1) & (number >> offset));
+        result = (result2 << 24) | result;
+    } else {
+        result = (((1 << length) - 1) & (number >> offset));
+
+    }
+    return result;
+}
+
+s32 CUSBMouseDevice::ExtractSigned(const void *buffer, u32 offset, u32 length) {
+    assert(buffer != 0);
+    assert(length <= 32);
+
+    unsigned result = ExtractUnsigned(buffer, offset, length);
+    if (length == 32) {
+        return result;
+    }
+    if (result & (1 << (length - 1))) {
+		result |= 0xffffffff - ((1 << length) - 1);
+	}
+    return result;
+}
+
+void CUSBMouseDevice::DecodeReport ()
+{
+	s32 item, arg;
+	u32 offset = 0, size = 0, count = 0;
+	u32 id = 0;
+    u32 nCollections = 0;
+    u32 itemIndex = 0;
+    u32 reportIndex = 0;
+    boolean parse = FALSE;
+
+	assert (m_pHIDReportDescriptor != 0);
+	s8 *pHIDReportDescriptor = (s8 *) m_pHIDReportDescriptor;
+
+	for (u16 usReportDescriptorLength = m_usReportDescriptorLength; usReportDescriptorLength > 0; )
+	{
+		item = *pHIDReportDescriptor++;
+		usReportDescriptorLength--;
+
+		switch(item & 0x03)
+		{
+		case 0:
+			arg = 0;
+			break;
+		case 1:
+			arg = *pHIDReportDescriptor++;
+			usReportDescriptorLength--;
+			break;
+		case 2:
+			arg = *pHIDReportDescriptor++ & 0xFF;
+			arg = arg | (*pHIDReportDescriptor++ << 8);
+			usReportDescriptorLength -= 2;
+			break;
+		default:
+			arg = *pHIDReportDescriptor++;
+			arg = arg | (*pHIDReportDescriptor++ << 8);
+			arg = arg | (*pHIDReportDescriptor++ << 16);
+			arg = arg | (*pHIDReportDescriptor++ << 24);
+			usReportDescriptorLength -= 4;
+			break;
+		}
+        //fprintf(stderr, "item, arg %02X %04X\n", item, arg);
+
+        switch(item & 0xFC)
+		{
+        case HID_COLLECTION:
+            nCollections++;
+            break;
+        case HID_END_COLLECTION:
+            nCollections--;
+            if (nCollections == 0)
+                parse = FALSE;
+            break;
+		case HID_USAGE_PAGE:
+			switch(arg)
+			{
+            case HID_USAGE_PAGE_GENERIC_DESKTOP:
+                //fprintf(stderr, "Generic Desktop Controls\n");
+                break;
+			}
+			break;
+		case HID_USAGE:
+			switch(arg)
+			{
+            case HID_USAGE_MOUSE:
+                parse = TRUE;
+                //fprintf(stderr, "state: Mouse\n");
+                break;
+            }
+            break;
+        }
+
+        if (! parse)
+            continue;
+
+		if ((item & 0xFC) == HID_REPORT_ID)
+		{
+            assert(id == 0);
+            if (id != 0){
+                break;
+            }
+			id = arg;
+			offset = 8;
+            //fprintf(stderr, "report ID %d\n", id);
+		}
+
+		switch(item & 0xFC)
+		{
+		case HID_USAGE_PAGE:
+			switch(arg)
+			{
+			case HID_USAGE_PAGE_BUTTONS:
+                //fprintf(stderr, "state: Mouse Buttons index %d\n", itemIndex);
+                m_ReportItems.items[itemIndex].type = MouseItemButtons;
+                itemIndex++;
+				break;
+			}
+			break;
+		case HID_USAGE:
+			switch(arg)
+			{
+			case HID_USAGE_X:
+                //fprintf(stderr, "state: Mouse X Axis index %d\n", itemIndex);
+                m_ReportItems.items[itemIndex].type = MouseItemXAxis;
+                itemIndex++;
+                break;
+			case HID_USAGE_Y:
+                //fprintf(stderr, "state: Mouse Y Axis index %d\n", itemIndex);
+                m_ReportItems.items[itemIndex].type = MouseItemYAxis;
+                itemIndex++;
+                break;
+            case HID_USAGE_WHEEL:
+                //fprintf(stderr, "state: Mouse Wheel index %d\n", itemIndex);
+                m_ReportItems.items[itemIndex].type = MouseItemWheel;
+                itemIndex++;
+                break;
+			}
+			break;
+		case HID_REPORT_SIZE:
+			size = arg;
+			break;
+		case HID_REPORT_COUNT:
+			count = arg;
+			break;
+		case HID_INPUT:
+			if ((arg & 0x03) == 0x02)
+			{
+                //fprintf(stderr, "item index %d, report index %d\n", itemIndex, reportIndex);
+                u32 tmp = offset;
+                while (reportIndex < itemIndex)
+                {
+                    TMouseReportItem *item = &m_ReportItems.items[reportIndex];
+                    switch (item->type)
+                    {
+                    case MouseItemButtons:
+                        item->count = count * size;
+                        item->offset = tmp;
+                        break;
+                    case MouseItemXAxis:
+                    case MouseItemYAxis:
+                    case MouseItemWheel:
+                        item->count = size;
+                        item->offset = tmp;
+                        break;
+                    }
+                    tmp += item->count;
+                    reportIndex++;
+                }
+            }
+            offset += count * size;
+			break;
+		}
+	}
+
+    m_ReportItems.id = id;
+    m_ReportItems.size = (offset + 7) / 8;
+    m_ReportItems.nItems = itemIndex;
+    CLogger::Get ()->Write (FromUSBMouse, LogDebug, "Report ID %d, size %d bytes, item count %d",
+                            m_ReportItems.id, m_ReportItems.size, m_ReportItems.nItems);
+    for (u32 i = 0; i < itemIndex; i++) {
+        CLogger::Get ()->Write (FromUSBMouse, LogDebug, "[%d] item ID %d offset %d, count %d",
+                                i, m_ReportItems.items[i].type, m_ReportItems.items[i].offset, m_ReportItems.items[i].count);
+    }
 }

--- a/lib/usb/usbmouse.cpp
+++ b/lib/usb/usbmouse.cpp
@@ -85,7 +85,9 @@ boolean CUSBMouseDevice::Configure (void)
 		return FALSE;
 	}
 
-	DecodeReport ();
+	unsigned nButtons = 0;
+	boolean bHasWheel = FALSE;
+	DecodeReport (&nButtons, &bHasWheel);
 
 	// ignoring unsupported HID interface
 	if (m_MouseReport.nItems == 0)
@@ -100,7 +102,7 @@ boolean CUSBMouseDevice::Configure (void)
 		return FALSE;
 	}
 
-	m_pMouseDevice = new CMouseDevice;
+	m_pMouseDevice = new CMouseDevice(nButtons, bHasWheel);
 	assert (m_pMouseDevice != 0);
 
 	return StartRequest ();
@@ -210,7 +212,7 @@ s32 CUSBMouseDevice::ExtractSigned(const void *buffer, u32 offset, u32 length)
 	return result;
 }
 
-void CUSBMouseDevice::DecodeReport ()
+void CUSBMouseDevice::DecodeReport (unsigned *nButtons, boolean *bHasWheel)
 {
 	s32 item, arg;
 	u32 offset = 0, size = 0, count = 0;
@@ -323,10 +325,13 @@ void CUSBMouseDevice::DecodeReport ()
 					case MouseItemButtons:
 						item->count = count * size;
 						item->offset = tmp;
+						*nButtons = item->count;
 						break;
+					case MouseItemWheel:
+						*bHasWheel = TRUE;
+						// fall thru
 					case MouseItemXAxis:
 					case MouseItemYAxis:
-					case MouseItemWheel:
 						item->count = size;
 						item->offset = tmp;
 						break;

--- a/sample/10-usbmouse/README
+++ b/sample/10-usbmouse/README
@@ -4,7 +4,8 @@ For this sample program you need to attach an USB mouse. First blink 5 times to
 show the image was loaded right. After initializing the screen is blank. Press
 the left or right mouse button and move the mouse to draw something onto the
 screen. If you have a mouse button in the middle you can press it to clear the
-screen.
+screen. If you have a wheel you can change the color of the pixels when drawing
+with the right mouse button.
 
 Because this sample is enabled for USB plug-and-play, the USB mouse can be
 attached or removed at any time while or before the system is running. It will

--- a/sample/10-usbmouse/kernel.cpp
+++ b/sample/10-usbmouse/kernel.cpp
@@ -34,7 +34,7 @@ CKernel::CKernel (void)
 	m_pMouse (0),
 	m_nPosX (0),
 	m_nPosY (0),
-	m_Color (COLOR16 (0, 0, 31)),
+	m_Color (HIGH_COLOR),
 	m_ShutdownMode (ShutdownNone)
 {
 	s_pThis = this;
@@ -116,6 +116,11 @@ TShutdownMode CKernel::Run (void)
 					m_Logger.Write (FromKernel, LogPanic, "Cannot setup mouse");
 				}
 
+				m_Logger.Write (FromKernel, LogNotice, "USB mouse has %d buttons",
+						m_pMouse->GetButtonCount());
+				m_Logger.Write (FromKernel, LogNotice, "USB mouse has %s wheel",
+						m_pMouse->HasWheel() ? "a" : "no");
+
 				m_nPosX = m_Screen.GetWidth () / 2;
 				m_nPosY = m_Screen.GetHeight () / 2;
 
@@ -160,7 +165,10 @@ void CKernel::MouseEventHandler (TMouseEvent Event, unsigned nButtons, unsigned 
 		break;
 
 	case MouseEventMouseWheel:
-		m_Color += nWheelMove * 16;
+		if (m_Color == HIGH_COLOR)
+			m_Color = HALF_COLOR;
+		else
+			m_Color = HIGH_COLOR;
 		break;
 
 	default:

--- a/sample/10-usbmouse/kernel.cpp
+++ b/sample/10-usbmouse/kernel.cpp
@@ -34,6 +34,7 @@ CKernel::CKernel (void)
 	m_pMouse (0),
 	m_nPosX (0),
 	m_nPosY (0),
+	m_Color (COLOR16 (0, 0, 31)),
 	m_ShutdownMode (ShutdownNone)
 {
 	s_pThis = this;
@@ -136,7 +137,7 @@ TShutdownMode CKernel::Run (void)
 	return m_ShutdownMode;
 }
 
-void CKernel::MouseEventHandler (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY)
+void CKernel::MouseEventHandler (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY, int nWheelMove)
 {
 	switch (Event)
 	{
@@ -144,7 +145,7 @@ void CKernel::MouseEventHandler (TMouseEvent Event, unsigned nButtons, unsigned 
 		if (nButtons & (MOUSE_BUTTON_LEFT | MOUSE_BUTTON_RIGHT))
 		{
 			DrawLine (m_nPosX, m_nPosY, nPosX, nPosY,
-				  nButtons & MOUSE_BUTTON_LEFT ? NORMAL_COLOR : HIGH_COLOR);
+				  nButtons & MOUSE_BUTTON_LEFT ? NORMAL_COLOR : m_Color);
 		}
 
 		m_nPosX = nPosX;
@@ -158,15 +159,19 @@ void CKernel::MouseEventHandler (TMouseEvent Event, unsigned nButtons, unsigned 
 		}
 		break;
 
+	case MouseEventMouseWheel:
+		m_Color += nWheelMove * 16;
+		break;
+
 	default:
 		break;
 	}
 }
 
-void CKernel::MouseEventStub (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY)
+void CKernel::MouseEventStub (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY, int nWheelMove)
 {
 	assert (s_pThis != 0);
-	s_pThis->MouseEventHandler (Event, nButtons, nPosX, nPosY);
+	s_pThis->MouseEventHandler (Event, nButtons, nPosX, nPosY, nWheelMove);
 }
 
 void CKernel::DrawLine (int nPosX1, int nPosY1, int nPosX2, int nPosY2, TScreenColor Color)

--- a/sample/10-usbmouse/kernel.h
+++ b/sample/10-usbmouse/kernel.h
@@ -52,8 +52,8 @@ public:
 	TShutdownMode Run (void);
 
 private:
-	void MouseEventHandler (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY);
-	static void MouseEventStub (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY);
+	void MouseEventHandler (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY, int nWheelMove);
+	static void MouseEventStub (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY, int nWheelMove);
 
 	void DrawLine (int nPosX1, int nPosY1, int nPosX2, int nPosY2, TScreenColor Color);
 
@@ -77,6 +77,7 @@ private:
 
 	unsigned m_nPosX;
 	unsigned m_nPosY;
+	TScreenColor m_Color;
 
 	volatile TShutdownMode m_ShutdownMode;
 


### PR DESCRIPTION
This can be considered an initial PR attempt as the code can be further improved and debugged, but I'm throwing it out there for others to tests and comment. Also the coding style might not match the rest of the code base.
Some code, specifically `TMouseReport` storage and its use in the `CUSBMouseDevice::ReportHandler()`, and the bit to integer extraction code `CUSBMouseDevice::ExtractUnsigned()` should be looked into.
Major parts and ideas were adopted from [this driver](https://github.com/rsta2/circle/blob/master/lib/usb/usbgamepadstandard.cpp) and that brings the possibility of creating a more generic HID report parsing, that could be used by all USB HID devices in the future. One thing to note is that the HID report descriptors are quite versatile and flexible as I found out in the last couple of days, and parsing them out in a safe and generic way might be a quite a challenge. So far, I tested this with three different USB mice, all with differing HID report descriptor content and layout.

A a direct consequence of the this change, support for mouse wheel is demonstrated in the updated 10-usbmouse sample. 

Here are the HID report descriptors I tested this with [parsed.log](https://github.com/rsta2/circle/files/5397622/parsed.log).

Here is the example serial dump of the detected USB mouse with the HID report descriptor and parsed report items:
```
logger: Circle 43.1 started on Raspberry Pi Zero W                                     
00:00:01.00 timer: SpeedFactor is 1.00                                                 
00:00:01.36 usbdev0-1: Device ven248a-8367 found
00:00:01.37 usbdev0-1: Interface int3-1-2 found
00:00:01.37 usbdev0-1: Using device/interface int3-1-2
00:00:01.38 usbdev0-1: Interface int3-1-1 found
00:00:01.38 usbdev0-1: Using device/interface int3-1-1
00:00:01.44 umouse: Report descriptor
00:00:01.45 umouse: Dumping 0x8E bytes starting at 0x50B120
00:00:01.45 umouse: B120: 05 01 09 02 A1 01 85 01-09 01 A1 00 05 09 19 01
00:00:01.46 umouse: B130: 29 05 15 00 25 01 95 05-75 01 81 02 95 01 75 03
00:00:01.46 umouse: B140: 81 01 05 01 09 30 09 31-15 81 25 7F 75 08 95 02
00:00:01.47 umouse: B150: 81 06 09 38 15 81 25 7F-75 08 95 01 81 06 C0 C0
00:00:01.48 umouse: B160: 05 0C 09 01 A1 01 85 03-75 10 95 02 15 01 26 8C
00:00:01.48 umouse: B170: 02 19 01 2A 8C 02 81 00-C0 05 01 09 80 A1 01 85
00:00:01.49 umouse: B180: 04 75 02 95 01 15 01 25-03 09 82 09 81 09 83 81
00:00:01.50 umouse: B190: 60 75 06 81 03 C0 05 01-09 00 A1 01 85 05 06 00
00:00:01.50 umouse: B1A0: FF 09 01 15 81 25 7F 75-08 95 07 B1 02 C0 A2 D2
00:00:01.51 umouse: Report ID 1, size 5 bytes, item count 4
00:00:01.52 umouse: [0] item ID 1 offset 8, count 5
00:00:01.52 umouse: [1] item ID 2 offset 16, count 8
00:00:01.52 umouse: [2] item ID 3 offset 24, count 8
00:00:01.53 umouse: [3] item ID 4 offset 32, count 8
00:00:01.54 dwroot: Device configured
00:00:01.54 kernel: Compile time: Oct 18 2020 15:36:14
00:00:01.55 kernel: Mouse attached
```

Looking forward to your comments and ideas!


![IMG_8910](https://user-images.githubusercontent.com/2725009/96370434-12816500-115e-11eb-905b-3564cddb4adf.jpg)
