### PR TITLE
support for 5 mouse buttons

### DIFF
--- a/include/circle/input/mousebehaviour.h
+++ b/include/circle/input/mousebehaviour.h
@@ -36,6 +36,8 @@ enum TMouseEvent
 #define MOUSE_BUTTON_LEFT	(1 << 0)
 #define MOUSE_BUTTON_RIGHT	(1 << 1)
 #define MOUSE_BUTTON_MIDDLE	(1 << 2)
+#define MOUSE_BUTTON_SIDE1	(1 << 3)
+#define MOUSE_BUTTON_SIDE2	(1 << 4)
 
 typedef void TMouseEventHandler (TMouseEvent Event, unsigned nButtons, unsigned nPosX, unsigned nPosY, int nWheelMove);
 

--- a/include/circle/usb/usbhid.h
+++ b/include/circle/usb/usbhid.h
@@ -71,5 +71,7 @@ PACKED;
 #define USBHID_BUTTON1	(1 << 0)
 #define USBHID_BUTTON2	(1 << 1)
 #define USBHID_BUTTON3	(1 << 2)
+#define USBHID_BUTTON4	(1 << 3)
+#define USBHID_BUTTON5	(1 << 4)
 
 #endif

--- a/lib/input/mousebehaviour.cpp
+++ b/lib/input/mousebehaviour.cpp
@@ -22,7 +22,7 @@
 #include <circle/bcm2835.h>
 #include <assert.h>
 
-#define MOUSE_BUTTONS		3
+#define MOUSE_BUTTONS		5
 
 #define ACCELERATION		18		// 1/10
 

--- a/lib/usb/usbmouse.cpp
+++ b/lib/usb/usbmouse.cpp
@@ -153,6 +153,14 @@ void CUSBMouseDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)
 			{
 				nButtons |= MOUSE_BUTTON_MIDDLE;
 			}
+            if (ucHIDButtons & USBHID_BUTTON4)
+			{
+				nButtons |= MOUSE_BUTTON_SIDE1;
+			}
+            if (ucHIDButtons & USBHID_BUTTON5)
+			{
+				nButtons |= MOUSE_BUTTON_SIDE2;
+			}
 
 			m_pMouseDevice->ReportHandler (nButtons, xMove, yMove, wheelMove);
 		}


### PR DESCRIPTION
Support for a mouse that has 5 buttons; two extra buttons are on the side of the mouse operated with a thumb.
The change is pretty trivial.

As an improvement, I would like to see `CMouseBehaviour::MouseStatusChanged()` looking at the `CMouseDevice::GetButtonCount()` instead of using `MOUSE_BUTTONS` define. Can't really see how that would come about at the moment without some API changes.