### PR TITLE
Usb serial

### DIFF
--- a/addon/gpio/Makefile
+++ b/addon/gpio/Makefile
@@ -1,0 +1,16 @@
+#
+# Makefile
+#
+
+CIRCLEHOME = ../..
+
+OBJS	= rtkgpio.o
+
+libgpio.a: $(OBJS)
+	@echo "  AR    $@"
+	@rm -f $@
+	@$(AR) cr $@ $(OBJS)
+
+include $(CIRCLEHOME)/Rules.mk
+
+-include $(DEPS)

--- a/addon/gpio/rtkgpio.cpp
+++ b/addon/gpio/rtkgpio.cpp
@@ -1,0 +1,245 @@
+//
+// rtkgpio.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2020  H. Kocevar <hinxx@protonmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <circle/logger.h>
+#include "rtkgpio.h"
+
+static const char FromRtkgpio[] = "rtkgpio";
+
+// Serial baudrate
+#define RTKGPIO_BAUD_RATE		230400
+
+// Define the lowest and highest GPIO pin numbers
+#define RTKGPIO_PIN_MIN			0
+#define RTKGPIO_PIN_MAX			27
+
+CRTKGpioDevice::CRTKGpioDevice (CUSBSerialCH341Device *pCH341)
+:	m_pCH341(pCH341)
+{
+	assert(m_pCH341 != 0);
+}
+
+CRTKGpioDevice::~CRTKGpioDevice ()
+{
+}
+
+boolean CRTKGpioDevice::Initialize (void)
+{
+	assert(m_pCH341 != 0);
+
+	if (!m_pCH341->SetBaudRate (RTKGPIO_BAUD_RATE))
+	{
+		return FALSE;
+	}
+
+	if (!GetVersion ())
+	{
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+boolean CRTKGpioDevice::GetVersion (void)
+{
+	if (m_pCH341->Write ("V?", 2) < 0)
+	{
+		CLogger::Get ()->Write (FromRtkgpio, LogError, "Write error V?");
+
+		return FALSE;
+	}
+
+	u8 rxData[32] = {0};
+	if (m_pCH341->Read (rxData, 32) < 0)
+	{
+		CLogger::Get ()->Write (FromRtkgpio, LogError, "Read error version");
+
+		return FALSE;
+	}
+
+	CLogger::Get ()->Write (FromRtkgpio, LogDebug, "firmware version: %s", rxData);
+
+	return TRUE;
+}
+
+boolean CRTKGpioDevice::SetPinDirectionOutput (unsigned nPin)
+{
+	return SetPinDirection (nPin, RtkGpioDirectionOutput);
+}
+
+boolean CRTKGpioDevice::SetPinDirectionInput (unsigned nPin)
+{
+	return SetPinDirection (nPin, RtkGpioDirectionInput);
+}
+
+boolean CRTKGpioDevice::SetPinPullNone(unsigned nPin)
+{
+	return SetPinPull (nPin, RtkGpioPullNone);
+}
+
+boolean CRTKGpioDevice::SetPinPullDown (unsigned nPin)
+{
+	return SetPinPull (nPin, RtkGpioPullDown);
+}
+
+boolean CRTKGpioDevice::SetPinPullUp (unsigned nPin)
+{
+	return SetPinPull (nPin, RtkGpioPullUp);
+}
+
+boolean CRTKGpioDevice::SetPinLevelLow (unsigned nPin)
+{
+	return SetPinLevel (nPin, RtkGpioLevelLow);
+}
+
+boolean CRTKGpioDevice::SetPinLevelHigh (unsigned nPin)
+{
+	return SetPinLevel (nPin, RtkGpioLevelHigh);
+}
+
+boolean CRTKGpioDevice::SetPinPull (unsigned nPin, TRtkGpioPull ePull)
+{
+	assert(nPin >= RTKGPIO_PIN_MIN && nPin <= RTKGPIO_PIN_MAX);
+
+	u8 cmd[3] = {0};
+	cmd[0] = 'G';
+	cmd[1] = (u8)(nPin + 'a');
+	switch (ePull) {
+	case RtkGpioPullNone:
+		cmd[2] = 'N';
+		break;
+	case RtkGpioPullDown:
+		cmd[2] = 'D';
+		break;
+	case RtkGpioPullUp:
+		cmd[2] = 'U';
+		break;
+	}
+
+	if (m_pCH341->Write (cmd, sizeof (cmd)) < 0)
+	{
+		CLogger::Get ()->Write (FromRtkgpio, LogError, "Failed to set pin %d pull", nPin);
+
+		return FALSE;
+	}
+	//CLogger::Get ()->Write (FromRtkgpio, LogDebug, "Pin %d pull %s", nPin,
+	//			ePull == RtkGpioPullNone ? "none" : (ePull == RtkGpioPullDown ? "down" : "up"));
+
+	return TRUE;
+}
+
+boolean CRTKGpioDevice::SetPinDirection (unsigned nPin, TRtkGpioDirection eDirection)
+{
+	assert(nPin >= RTKGPIO_PIN_MIN && nPin <= RTKGPIO_PIN_MAX);
+
+	u8 cmd[3] = {0};
+	cmd[0] = 'G';
+	cmd[1] = (u8)(nPin + 'a');
+	switch (eDirection) {
+	case RtkGpioDirectionOutput:
+		cmd[2] = 'O';
+		break;
+	case RtkGpioDirectionInput:
+		cmd[2] = 'I';
+		break;
+	}
+
+	if (m_pCH341->Write (cmd, sizeof (cmd)) < 0)
+	{
+		CLogger::Get ()->Write (FromRtkgpio, LogError, "Failed to set pin %d direction", nPin);
+
+		return FALSE;
+	}
+	//CLogger::Get ()->Write (FromRtkgpio, LogDebug, "Pin %d direction %s", nPin,
+	//			eDirection == RtkGpioDirectionInput ? "input" : "output");
+
+	return TRUE;
+}
+
+boolean CRTKGpioDevice::SetPinLevel (unsigned nPin, TRtkGpioLevel eLevel)
+{
+	assert(nPin >= RTKGPIO_PIN_MIN && nPin <= RTKGPIO_PIN_MAX);
+
+	u8 cmd[3] = {0};
+	cmd[0] = 'G';
+	cmd[1] = (u8)(nPin + 'a');
+	switch (eLevel) {
+	case RtkGpioLevelLow:
+		cmd[2] = '0';
+		break;
+	case RtkGpioLevelHigh:
+		cmd[2] = '1';
+		break;
+	case RtkGpioLevelUnknown:
+		CLogger::Get ()->Write (FromRtkgpio, LogError, "Invalid pin %d level", nPin);
+		return FALSE;
+		break;
+	}
+
+	if (m_pCH341->Write (cmd, sizeof (cmd)) < 0)
+	{
+		CLogger::Get ()->Write (FromRtkgpio, LogError, "Failed to set pin %d level", nPin);
+
+		return FALSE;
+	}
+	//CLogger::Get ()->Write (FromRtkgpio, LogDebug, "Pin %d level %s", nPin,
+	//			eLevel == RtkGpioLevelLow ? "low" : "high");
+
+	return TRUE;
+}
+
+TRtkGpioLevel CRTKGpioDevice::GetPinLevel (unsigned nPin)
+{
+	assert(nPin >= RTKGPIO_PIN_MIN && nPin <= RTKGPIO_PIN_MAX);
+
+	u8 cmd[3] = {0};
+	cmd[0] = 'G';
+	cmd[1] = (u8)(nPin + 'a');
+	cmd[2] = '?';
+	if (m_pCH341->Write (cmd, sizeof (cmd)) < 0)
+	{
+		CLogger::Get ()->Write (FromRtkgpio, LogError, "Failed to get pin %d level", nPin);
+
+		return RtkGpioLevelUnknown;
+	}
+
+	u8 rxData[4] = {0};
+	if (m_pCH341->Read (rxData, 4) < 0)
+	{
+		CLogger::Get ()->Write (FromRtkgpio, LogError, "Read error");
+
+		return RtkGpioLevelUnknown;
+	}
+	//CLogger::Get ()->Write (FromRtkgpio, LogDebug, "Read %s %2X %2X %2X %2X",
+	//			cmd, rxData[0], rxData[1], rxData[2], rxData[3]);
+
+	switch (rxData[1]) {
+	case '0':
+		//CLogger::Get ()->Write (FromRtkgpio, LogDebug, "Pin %d level low", nPin);
+		return RtkGpioLevelLow;
+		break;
+	case '1':
+		//CLogger::Get ()->Write (FromRtkgpio, LogDebug, "Pin %d level high", nPin);
+		return RtkGpioLevelHigh;
+		break;
+	}
+
+	CLogger::Get ()->Write (FromRtkgpio, LogError, "Invalid level");
+	return RtkGpioLevelUnknown;
+}

--- a/addon/gpio/rtkgpio.h
+++ b/addon/gpio/rtkgpio.h
@@ -1,0 +1,74 @@
+//
+// rtkgpio.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2020  H. Kocevar <hinxx@protonmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _gpio_rtkgpio_h
+#define _gpio_rtkgpio_h
+
+#include <circle/usb/usbserialch341.h>
+#include <circle/types.h>
+
+enum TRtkGpioDirection
+{
+	RtkGpioDirectionOutput,
+	RtkGpioDirectionInput
+};
+
+enum TRtkGpioLevel
+{
+	RtkGpioLevelUnknown,
+	RtkGpioLevelLow,
+	RtkGpioLevelHigh
+};
+
+enum TRtkGpioPull
+{
+	RtkGpioPullNone,
+	RtkGpioPullDown,
+	RtkGpioPullUp
+};
+
+class CRTKGpioDevice
+{
+public:
+	CRTKGpioDevice (CUSBSerialCH341Device *pCH341);
+	~CRTKGpioDevice ();
+
+	boolean Initialize (void);
+	boolean GetVersion (void);
+
+	boolean SetPinDirection (unsigned nPin, TRtkGpioDirection eDirection);
+	boolean SetPinDirectionOutput (unsigned nPin);
+	boolean SetPinDirectionInput (unsigned nPin);
+
+	boolean SetPinPull (unsigned nPin, TRtkGpioPull ePull);
+	boolean SetPinPullUp (unsigned nPin);
+	boolean SetPinPullDown (unsigned nPin);
+	boolean SetPinPullNone (unsigned nPin);
+
+	boolean SetPinLevel (unsigned nPin, TRtkGpioLevel eLevel);
+	boolean SetPinLevelLow (unsigned nPin);
+	boolean SetPinLevelHigh (unsigned nPin);
+
+	TRtkGpioLevel GetPinLevel (unsigned nPin);
+
+private:
+	CUSBSerialCH341Device	*m_pCH341;
+};
+
+#endif

--- a/addon/gpio/sample/rtkgpio/Makefile
+++ b/addon/gpio/sample/rtkgpio/Makefile
@@ -6,7 +6,8 @@ CIRCLEHOME = ../../../..
 
 OBJS	= main.o kernel.o
 
-LIBS	= $(CIRCLEHOME)/lib/usb/libusb.a \
+LIBS	= $(CIRCLEHOME)/addon/gpio/libgpio.a \
+	  $(CIRCLEHOME)/lib/usb/libusb.a \
 	  $(CIRCLEHOME)/lib/input/libinput.a \
 	  $(CIRCLEHOME)/lib/fs/libfs.a \
 	  $(CIRCLEHOME)/lib/libcircle.a

--- a/addon/gpio/sample/rtkgpio/README
+++ b/addon/gpio/sample/rtkgpio/README
@@ -1,10 +1,9 @@
 README
 
 To use this sample program you need a RTK.GPIO board allowing you to increase the number of GPIO pins.
-RTK.GPIO board uses USB to serial IC Winchiphead CH341/CH340 to communicate to Raspberry Pi.
+RTK.GPIO board uses USB to serial IC Winchiphead CH340 to communicate to Raspberry Pi.
 The board must be connected to an USB port of the Raspberry Pi and ready when the Raspberry Pi is started.
 
 First blink 5 times to show the image was loaded right.
-After initializing the USB driver stack the sample program first toggles the level of a single GPIO output
-a couple of times (can be connected to a LED).
-Afterwards, another GPIO pin configured as input samples the level (can be connected to a button).
+After initializing the USB driver stack the sample program drives GPIO0 - GPIO7 outputs
+(can be connected to a LED), and polls the level of GPIO22 - GPIO25 inputs (can be connected to a button).

--- a/addon/gpio/sample/rtkgpio/kernel.cpp
+++ b/addon/gpio/sample/rtkgpio/kernel.cpp
@@ -18,8 +18,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 #include "kernel.h"
-#include <circle/usb/usbserialch341.h>
 #include <circle/string.h>
+#include <circle/usb/usbserialch341.h>
+#include <gpio/rtkgpio.h>
 
 static const char FromKernel[] = "kernel";
 
@@ -83,70 +84,70 @@ TShutdownMode CKernel::Run (void)
 {
 	m_Logger.Write (FromKernel, LogNotice, "Compile time: " __DATE__ " " __TIME__);
 
-	CUSBSerialCH341Device *pUSerial1 = reinterpret_cast<CUSBSerialCH341Device *>(m_DeviceNameService.GetDevice ("utty1", FALSE));
+	CUSBSerialCH341Device *pUSerial1 = (CUSBSerialCH341Device *)(m_DeviceNameService.GetDevice ("utty1", FALSE));
 	if (pUSerial1 == 0)
 	{
 		m_Logger.Write (FromKernel, LogPanic, "USB serial device not found");
 	}
 
-	pUSerial1->SetBaudRate(230400);
-
-	if (pUSerial1->Write ("vO", 2) < 0)
+	CDevice *pTarget = m_DeviceNameService.GetDevice (m_Options.GetLogDevice (), FALSE);
+	if (pTarget == 0)
 	{
-		m_Logger.Write (FromKernel, LogError, "Write error vO");
-	}
-	m_Logger.Write (FromKernel, LogDebug, "Write vO");
-	if (pUSerial1->Write ("vN", 2) < 0)
-	{
-		m_Logger.Write (FromKernel, LogError, "Write error vN");
-	}
-	m_Logger.Write (FromKernel, LogDebug, "Write vN");
-
-	int iter = 20;
-	while (iter--)
-	{
-		if (pUSerial1->Write ("v0", 2) < 0)
-		{
-			m_Logger.Write (FromKernel, LogError, "Write error v0");
-		}
-		m_Logger.Write (FromKernel, LogDebug, "Write v0");
-		m_Timer.SimpleMsDelay(500);
-		if (pUSerial1->Write ("v1", 2) < 0)
-		{
-			m_Logger.Write (FromKernel, LogError, "Write error v1");
-		}
-		m_Logger.Write (FromKernel, LogDebug, "Write v1");
-		m_Timer.SimpleMsDelay(500);
+		pTarget = &m_Screen;
 	}
 
-	if (pUSerial1->Write ("uI", 2) < 0)
-	{
-		m_Logger.Write (FromKernel, LogError, "Write error uI");
-	}
-	m_Logger.Write (FromKernel, LogDebug, "Write uI");
-	if (pUSerial1->Write ("uN", 2) < 0)
-	{
-		m_Logger.Write (FromKernel, LogError, "Write error uN");
-	}
-	m_Logger.Write (FromKernel, LogDebug, "Write uN");
+	CRTKGpioDevice rtkgpio(pUSerial1);
+	rtkgpio.Initialize();
 
-	u8 rxData[5];
-	iter = 20;
-	while (iter--)
+	for (unsigned i = 22; i < 26; i++)
 	{
-		if (pUSerial1->Write ("u?", 2) < 0)
-		{
-			m_Logger.Write (FromKernel, LogError, "Write error u?");
-		}
-		m_Logger.Write (FromKernel, LogDebug, "Write u?");
-		m_Timer.SimpleMsDelay(500);
-		if (pUSerial1->Read (rxData, 4) < 0)
-		{
-			m_Logger.Write (FromKernel, LogError, "Read error");
-		}
-		m_Logger.Write (FromKernel, LogDebug, "Read u? %2X %2X %2X %2X", rxData[0], rxData[1], rxData[2], rxData[3]);
-		m_Timer.SimpleMsDelay(500);
+		rtkgpio.SetPinDirectionInput (i);
+		rtkgpio.SetPinPullNone (i);
 	}
+
+	for (unsigned i = 0; i < 8; i++)
+	{
+		rtkgpio.SetPinDirectionOutput (i);
+		rtkgpio.SetPinPullNone (i);
+		rtkgpio.SetPinLevelHigh (i);
+	}
+
+	CString status;
+
+	for (unsigned i = 0; i < 256; i++)
+	{
+		status.Append("\routputs:");
+		for (unsigned b = 0; b < 8; b++)
+		{
+			if (!(i & (1 << b)))
+			{
+				rtkgpio.SetPinLevelHigh (b);
+				status.Append(" H");
+			}
+			else
+			{
+				rtkgpio.SetPinLevelLow (b);
+				status.Append(" L");
+			}
+		}
+		status.Append("\tinputs:");
+		for (unsigned b = 22; b < 26; b++)
+		{
+			if (rtkgpio.GetPinLevel (b) == RtkGpioLevelLow)
+			{
+				status.Append(" L");
+			}
+			else
+			{
+				status.Append(" H");
+			}
+		}
+		CTimer::SimpleMsDelay (100);
+
+		pTarget->Write (status, status.GetLength());
+	}
+
+	m_Logger.Write(FromKernel, LogNotice, "\nDone!");
 
 	return ShutdownReboot;
 }

--- a/addon/gpio/sample/rtkgpio/kernel.cpp
+++ b/addon/gpio/sample/rtkgpio/kernel.cpp
@@ -84,7 +84,7 @@ TShutdownMode CKernel::Run (void)
 {
 	m_Logger.Write (FromKernel, LogNotice, "Compile time: " __DATE__ " " __TIME__);
 
-	CUSBSerialCH341Device *pUSerial1 = (CUSBSerialCH341Device *)(m_DeviceNameService.GetDevice ("utty1", FALSE));
+	CUSBSerialCH341Device *pUSerial1 = (CUSBSerialCH341Device *) (m_DeviceNameService.GetDevice ("utty1", FALSE));
 	if (pUSerial1 == 0)
 	{
 		m_Logger.Write (FromKernel, LogPanic, "USB serial device not found");
@@ -96,8 +96,8 @@ TShutdownMode CKernel::Run (void)
 		pTarget = &m_Screen;
 	}
 
-	CRTKGpioDevice rtkgpio(pUSerial1);
-	rtkgpio.Initialize();
+	CRTKGpioDevice rtkgpio (pUSerial1);
+	rtkgpio.Initialize ();
 
 	for (unsigned i = 22; i < 26; i++)
 	{
@@ -116,38 +116,38 @@ TShutdownMode CKernel::Run (void)
 
 	for (unsigned i = 0; i < 256; i++)
 	{
-		status.Append("\routputs:");
+		status.Append ("\routputs:");
 		for (unsigned b = 0; b < 8; b++)
 		{
 			if (!(i & (1 << b)))
 			{
 				rtkgpio.SetPinLevelHigh (b);
-				status.Append(" H");
+				status.Append (" H");
 			}
 			else
 			{
 				rtkgpio.SetPinLevelLow (b);
-				status.Append(" L");
+				status.Append (" L");
 			}
 		}
-		status.Append("\tinputs:");
+		status.Append ("\tinputs:");
 		for (unsigned b = 22; b < 26; b++)
 		{
 			if (rtkgpio.GetPinLevel (b) == RtkGpioLevelLow)
 			{
-				status.Append(" L");
+				status.Append (" L");
 			}
 			else
 			{
-				status.Append(" H");
+				status.Append (" H");
 			}
 		}
-		CTimer::SimpleMsDelay (100);
 
-		pTarget->Write (status, status.GetLength());
+		pTarget->Write (status, status.GetLength ());
+		CTimer::SimpleMsDelay (500);
 	}
 
-	m_Logger.Write(FromKernel, LogNotice, "\nDone!");
+	m_Logger.Write (FromKernel, LogNotice, "\nDone!");
 
 	return ShutdownReboot;
 }

--- a/include/circle/usb/usbserial.h
+++ b/include/circle/usb/usbserial.h
@@ -65,6 +65,10 @@ protected:
 	TUSBSerialDataBits m_nDataBits;
 	TUSBSerialParity m_nParity;
 	TUSBSerialStopBits m_nStopBits;
+	u8 *m_pBufferIn;
+	size_t m_nBufferInSize;
+	u8 *m_pBufferOut;
+	size_t m_nBufferOutSize;
 
 private:
 	CUSBEndpoint *m_pEndpointIn;

--- a/include/circle/usb/usbserial.h
+++ b/include/circle/usb/usbserial.h
@@ -65,14 +65,14 @@ protected:
 	TUSBSerialDataBits m_nDataBits;
 	TUSBSerialParity m_nParity;
 	TUSBSerialStopBits m_nStopBits;
-	u8 *m_pBufferIn;
-	size_t m_nBufferInSize;
-	u8 *m_pBufferOut;
-	size_t m_nBufferOutSize;
 
 private:
 	CUSBEndpoint *m_pEndpointIn;
 	CUSBEndpoint *m_pEndpointOut;
+	u8 *m_pBufferIn;
+	size_t m_nBufferInSize;
+	u8 *m_pBufferOut;
+	size_t m_nBufferOutSize;
 
 	unsigned m_nDeviceNumber;
 	static CNumberPool s_DeviceNumberPool;

--- a/include/circle/usb/usbserialch341.h
+++ b/include/circle/usb/usbserialch341.h
@@ -32,7 +32,8 @@ public:
 
 	boolean Configure (void);
 	boolean SetBaudRate (unsigned nBaudRate);
-	boolean SetLineProperties (TUSBSerialDataBits nDataBits, TUSBSerialParity nParity, TUSBSerialStopBits nStopBits);
+	boolean SetLineProperties (TUSBSerialDataBits nDataBits,
+				   TUSBSerialParity nParity, TUSBSerialStopBits nStopBits);
 
 	static const TUSBDeviceID *GetDeviceIDTable (void);
 };

--- a/include/circle/usb/usbserialcp2102.h
+++ b/include/circle/usb/usbserialcp2102.h
@@ -32,7 +32,8 @@ public:
 
 	boolean Configure (void);
 	boolean SetBaudRate (unsigned nBaudRate);
-	boolean SetLineProperties (TUSBSerialDataBits nDataBits, TUSBSerialParity nParity, TUSBSerialStopBits nStopBits);
+	boolean SetLineProperties (TUSBSerialDataBits nDataBits,
+				   TUSBSerialParity nParity, TUSBSerialStopBits nStopBits);
 
 	static const TUSBDeviceID *GetDeviceIDTable (void);
 };

--- a/include/circle/usb/usbserialcp2102.h
+++ b/include/circle/usb/usbserialcp2102.h
@@ -1,0 +1,40 @@
+//
+// usbserialcp2102.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2020  H. Kocevar <hinxx@protonmail.com>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _circle_usb_usbserialcp2102_h
+#define _circle_usb_usbserialcp2102_h
+
+#include <circle/usb/usbserial.h>
+#include <circle/usb/usbdevicefactory.h>
+#include <circle/types.h>
+
+class CUSBSerialCP2102Device : public CUSBSerialDevice
+{
+public:
+	CUSBSerialCP2102Device (CUSBFunction *pFunction);
+	~CUSBSerialCP2102Device (void);
+
+	boolean Configure (void);
+	boolean SetBaudRate (unsigned nBaudRate);
+	boolean SetLineProperties (TUSBSerialDataBits nDataBits, TUSBSerialParity nParity, TUSBSerialStopBits nStopBits);
+
+	static const TUSBDeviceID *GetDeviceIDTable (void);
+};
+
+#endif

--- a/include/circle/usb/usbserialft231x.h
+++ b/include/circle/usb/usbserialft231x.h
@@ -1,0 +1,43 @@
+//
+// usbserialft231x.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2020  H. Kocevar <hinxx@protonmail.com>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _circle_usb_usbserialft231x_h
+#define _circle_usb_usbserialft231x_h
+
+#include <circle/usb/usbserial.h>
+#include <circle/usb/usbdevicefactory.h>
+#include <circle/types.h>
+
+class CUSBSerialFT231XDevice : public CUSBSerialDevice
+{
+public:
+	CUSBSerialFT231XDevice (CUSBFunction *pFunction);
+	~CUSBSerialFT231XDevice (void);
+
+	boolean Configure (void);
+	boolean SetBaudRate (unsigned nBaudRate);
+	boolean SetLineProperties (TUSBSerialDataBits nDataBits,
+				   TUSBSerialParity nParity, TUSBSerialStopBits nStopBits);
+
+	int Read (void *pBuffer, size_t nCount);
+
+	static const TUSBDeviceID *GetDeviceIDTable (void);
+};
+
+#endif

--- a/include/circle/usb/usbserialpl2303.h
+++ b/include/circle/usb/usbserialpl2303.h
@@ -1,0 +1,41 @@
+//
+// usbserialpl2303.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2020  H. Kocevar <hinxx@protonmail.com>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _circle_usb_usbserialpl2303_h
+#define _circle_usb_usbserialpl2303_h
+
+#include <circle/usb/usbserial.h>
+#include <circle/usb/usbdevicefactory.h>
+#include <circle/types.h>
+
+class CUSBSerialPL2303Device : public CUSBSerialDevice
+{
+public:
+	CUSBSerialPL2303Device (CUSBFunction *pFunction);
+	~CUSBSerialPL2303Device (void);
+
+	boolean Configure (void);
+	boolean SetBaudRate (unsigned nBaudRate);
+	boolean SetLineProperties (TUSBSerialDataBits nDataBits,
+				   TUSBSerialParity nParity, TUSBSerialStopBits nStopBits);
+
+	static const TUSBDeviceID *GetDeviceIDTable (void);
+};
+
+#endif

--- a/lib/usb/Makefile
+++ b/lib/usb/Makefile
@@ -30,7 +30,7 @@ OBJS	= lan7800.o smsc951x.o usbbluetooth.o usbcdcethernet.o \
 	  usbgamepadxbox360.o usbgamepadxboxone.o usbhiddevice.o usbhostcontroller.o \
 	  usbkeyboard.o usbmassdevice.o usbmidi.o usbmouse.o usbprinter.o usbrequest.o \
 	  usbstandardhub.o usbstring.o usbserial.o usbserialch341.o usbserialcp2102.o \
-	  usbserialpl2303.o
+	  usbserialpl2303.o usbserialft231x.o
 
 ifneq ($(strip $(RASPPI)),4)
 OBJS	+= dwhcidevice.o dwhciframeschednper.o dwhciframeschednsplit.o dwhciframeschedper.o \

--- a/lib/usb/Makefile
+++ b/lib/usb/Makefile
@@ -29,7 +29,7 @@ OBJS	= lan7800.o smsc951x.o usbbluetooth.o usbcdcethernet.o \
 	  usbgamepad.o usbgamepadps3.o usbgamepadps4.o usbgamepadstandard.o usbgamepadswitchpro.o \
 	  usbgamepadxbox360.o usbgamepadxboxone.o usbhiddevice.o usbhostcontroller.o \
 	  usbkeyboard.o usbmassdevice.o usbmidi.o usbmouse.o usbprinter.o usbrequest.o \
-	  usbstandardhub.o usbstring.o usbserial.o usbserialch341.o
+	  usbstandardhub.o usbstring.o usbserial.o usbserialch341.o usbserialcp2102.o
 
 ifneq ($(strip $(RASPPI)),4)
 OBJS	+= dwhcidevice.o dwhciframeschednper.o dwhciframeschednsplit.o dwhciframeschedper.o \

--- a/lib/usb/Makefile
+++ b/lib/usb/Makefile
@@ -29,7 +29,8 @@ OBJS	= lan7800.o smsc951x.o usbbluetooth.o usbcdcethernet.o \
 	  usbgamepad.o usbgamepadps3.o usbgamepadps4.o usbgamepadstandard.o usbgamepadswitchpro.o \
 	  usbgamepadxbox360.o usbgamepadxboxone.o usbhiddevice.o usbhostcontroller.o \
 	  usbkeyboard.o usbmassdevice.o usbmidi.o usbmouse.o usbprinter.o usbrequest.o \
-	  usbstandardhub.o usbstring.o usbserial.o usbserialch341.o usbserialcp2102.o
+	  usbstandardhub.o usbstring.o usbserial.o usbserialch341.o usbserialcp2102.o \
+	  usbserialpl2303.o
 
 ifneq ($(strip $(RASPPI)),4)
 OBJS	+= dwhcidevice.o dwhciframeschednper.o dwhciframeschednsplit.o dwhciframeschedper.o \

--- a/lib/usb/usbdevicefactory.cpp
+++ b/lib/usb/usbdevicefactory.cpp
@@ -39,6 +39,7 @@
 #include <circle/usb/usbcdcethernet.h>
 #include <circle/usb/usbserialch341.h>
 #include <circle/usb/usbserialcp2102.h>
+#include <circle/usb/usbserialpl2303.h>
 
 CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pName)
 {
@@ -127,6 +128,10 @@ CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pNam
 	else if (FindDeviceID (pName, CUSBSerialCP2102Device::GetDeviceIDTable ()))
 	{
 		pResult = new CUSBSerialCP2102Device (pParent);
+	}
+	else if (FindDeviceID (pName, CUSBSerialPL2303Device::GetDeviceIDTable ()))
+	{
+		pResult = new CUSBSerialPL2303Device (pParent);
 	}
 	// new devices follow
 

--- a/lib/usb/usbdevicefactory.cpp
+++ b/lib/usb/usbdevicefactory.cpp
@@ -38,6 +38,7 @@
 #include <circle/usb/usbmidi.h>
 #include <circle/usb/usbcdcethernet.h>
 #include <circle/usb/usbserialch341.h>
+#include <circle/usb/usbserialcp2102.h>
 
 CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pName)
 {
@@ -122,6 +123,10 @@ CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pNam
 	else if (FindDeviceID (pName, CUSBSerialCH341Device::GetDeviceIDTable ()))
 	{
 		pResult = new CUSBSerialCH341Device (pParent);
+	}
+	else if (FindDeviceID (pName, CUSBSerialCP2102Device::GetDeviceIDTable ()))
+	{
+		pResult = new CUSBSerialCP2102Device (pParent);
 	}
 	// new devices follow
 

--- a/lib/usb/usbdevicefactory.cpp
+++ b/lib/usb/usbdevicefactory.cpp
@@ -40,6 +40,7 @@
 #include <circle/usb/usbserialch341.h>
 #include <circle/usb/usbserialcp2102.h>
 #include <circle/usb/usbserialpl2303.h>
+#include <circle/usb/usbserialft231x.h>
 
 CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pName)
 {
@@ -132,6 +133,10 @@ CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pNam
 	else if (FindDeviceID (pName, CUSBSerialPL2303Device::GetDeviceIDTable ()))
 	{
 		pResult = new CUSBSerialPL2303Device (pParent);
+	}
+	else if (FindDeviceID (pName, CUSBSerialFT231XDevice::GetDeviceIDTable ()))
+	{
+		pResult = new CUSBSerialFT231XDevice (pParent);
 	}
 	// new devices follow
 

--- a/lib/usb/usbserial.cpp
+++ b/lib/usb/usbserial.cpp
@@ -193,14 +193,15 @@ int CUSBSerialDevice::Read (void *pBuffer, size_t nCount)
 	return nActual;
 }
 
-
 boolean CUSBSerialDevice::SetBaudRate (unsigned nBaudRate)
 {
 	(void)nBaudRate;
 	return TRUE;
 }
 
-boolean CUSBSerialDevice::SetLineProperties (TUSBSerialDataBits nDataBits, TUSBSerialParity nParity, TUSBSerialStopBits nStopBits)
+boolean CUSBSerialDevice::SetLineProperties (TUSBSerialDataBits nDataBits,
+					     TUSBSerialParity nParity,
+					     TUSBSerialStopBits nStopBits)
 {
 	(void)nDataBits;
 	(void)nParity;

--- a/lib/usb/usbserial.cpp
+++ b/lib/usb/usbserial.cpp
@@ -188,6 +188,11 @@ int CUSBSerialDevice::Read (void *pBuffer, size_t nCount)
 		return -1;
 	}
 
+	if (nCount < (size_t) nActual)
+	{
+		nActual = nCount;
+	}
+
 	memcpy (pBuffer, m_pBufferIn, nActual);
 
 	return nActual;

--- a/lib/usb/usbserial.cpp
+++ b/lib/usb/usbserial.cpp
@@ -119,12 +119,15 @@ int CUSBSerialDevice::Write (const void *pBuffer, size_t nCount)
 	CUSBHostController *pHost = GetHost ();
 	assert (pHost != 0);
 
-	if (pHost->Transfer (m_pEndpointOut, (void *) pBuffer, nCount) < 0)
+	int nActual = pHost->Transfer (m_pEndpointOut, (void *) pBuffer, nCount);
+	if (nActual < 0)
 	{
+		CLogger::Get ()->Write (FromSerial, LogError, "USB write failed");
+
 		return -1;
 	}
 
-	return nCount;
+	return nActual;
 }
 
 int CUSBSerialDevice::Read (void *pBuffer, size_t nCount)
@@ -135,12 +138,15 @@ int CUSBSerialDevice::Read (void *pBuffer, size_t nCount)
 	CUSBHostController *pHost = GetHost ();
 	assert (pHost != 0);
 
-	if (pHost->Transfer (m_pEndpointIn, (void *) pBuffer, nCount) < 0)
+	int nActual = pHost->Transfer (m_pEndpointIn, (void *) pBuffer, nCount);
+	if (nActual < 0)
 	{
+		CLogger::Get ()->Write (FromSerial, LogError, "USB read failed");
+
 		return -1;
 	}
 
-	return nCount;
+	return nActual;
 }
 
 

--- a/lib/usb/usbserial.cpp
+++ b/lib/usb/usbserial.cpp
@@ -180,7 +180,7 @@ int CUSBSerialDevice::Read (void *pBuffer, size_t nCount)
 		m_nBufferInSize = count;
 	}
 
-	int nActual = pHost->Transfer (m_pEndpointIn, (void *) m_pBufferIn, m_nBufferInSize);
+	int nActual = pHost->Transfer (m_pEndpointIn, (void *) m_pBufferIn, count);
 	if (nActual < 0)
 	{
 		CLogger::Get ()->Write (FromSerial, LogError, "USB read failed");

--- a/lib/usb/usbserialch341.cpp
+++ b/lib/usb/usbserialch341.cpp
@@ -33,17 +33,11 @@ static const char FromCh341[] = "ch341";
 
 #define CH341_REQ_READ_VERSION 0x5F
 #define CH341_REQ_WRITE_REG    0x9A
-#define CH341_REQ_READ_REG     0x95
 #define CH341_REQ_SERIAL_INIT  0xA1
 #define CH341_REQ_MODEM_CTRL   0xA4
 
-#define CH341_REG_BREAK        0x05
-#define CH341_REG_LCR          0x18
-#define CH341_NBREAK_BITS      0x01
-
 #define CH341_LCR_ENABLE_RX    0x80
 #define CH341_LCR_ENABLE_TX    0x40
-#define CH341_LCR_MARK_SPACE   0x20
 #define CH341_LCR_PAR_EVEN     0x10
 #define CH341_LCR_ENABLE_PAR   0x08
 #define CH341_LCR_STOP_BITS_2  0x04
@@ -147,7 +141,7 @@ boolean CUSBSerialCH341Device::SetBaudRate (unsigned nBaudRate)
 				   a,
 				   0, 0) < 0)
 	{
-		CLogger::Get ()->Write (FromCh341, LogError, "Cannot init serial port factor/divisor");
+		CLogger::Get ()->Write (FromCh341, LogError, "Cannot setup baud rate");
 
 		return FALSE;
 	}
@@ -158,7 +152,9 @@ boolean CUSBSerialCH341Device::SetBaudRate (unsigned nBaudRate)
 	return TRUE;
 }
 
-boolean CUSBSerialCH341Device::SetLineProperties (TUSBSerialDataBits nDataBits, TUSBSerialParity nParity, TUSBSerialStopBits nStopBits)
+boolean CUSBSerialCH341Device::SetLineProperties (TUSBSerialDataBits nDataBits,
+						  TUSBSerialParity nParity,
+						  TUSBSerialStopBits nStopBits)
 {
 	CUSBHostController *pHost = GetHost ();
 	assert (pHost != 0);

--- a/lib/usb/usbserialch341.cpp
+++ b/lib/usb/usbserialch341.cpp
@@ -181,19 +181,19 @@ boolean CUSBSerialCH341Device::SetLineProperties (TUSBSerialDataBits nDataBits,
 		return FALSE;
 		break;
 	}
-	framing.Format("%d", nDataBits);
+	framing.Format ("%d", nDataBits);
 
 	switch (nParity) {
 	case USBSerialParityNone:
-		framing.Append("N");
+		framing.Append ("N");
 		break;
 	case USBSerialParityOdd:
 		lcr |= CH341_LCR_ENABLE_PAR;
-		framing.Append("O");
+		framing.Append ("O");
 		break;
 	case USBSerialParityEven:
 		lcr |= CH341_LCR_ENABLE_PAR | CH341_LCR_PAR_EVEN;
-		framing.Append("E");
+		framing.Append ("E");
 		break;
 	default:
 		CLogger::Get ()->Write (FromCh341, LogError, "Invalid parity %d", nParity);
@@ -203,11 +203,11 @@ boolean CUSBSerialCH341Device::SetLineProperties (TUSBSerialDataBits nDataBits,
 
 	switch (nStopBits) {
 	case USBSerialStopBits1:
-		framing.Append("1");
+		framing.Append ("1");
 		break;
 	case USBSerialStopBits2:
 		lcr |= CH341_LCR_STOP_BITS_2;
-		framing.Append("2");
+		framing.Append ("2");
 		break;
 	default:
 		CLogger::Get ()->Write (FromCh341, LogError, "Invalid stop bits %d", nStopBits);

--- a/lib/usb/usbserialcp2102.cpp
+++ b/lib/usb/usbserialcp2102.cpp
@@ -31,8 +31,6 @@ static const char FromCp2102[] = "cp2102";
 // Config request codes
 #define CP210X_IFC_ENABLE	0x00
 #define CP210X_SET_LINE_CTL	0x03
-#define CP210X_GET_LINE_CTL	0x04
-#define CP210X_GET_BAUDRATE	0x1D
 #define CP210X_SET_BAUDRATE	0x1E
 #define CP210X_VENDOR_SPECIFIC	0xFF
 
@@ -41,23 +39,16 @@ static const char FromCp2102[] = "cp2102";
 #define UART_DISABLE		0x0000
 
 // CP210X_(SET|GET)_LINE_CTL
-#define BITS_DATA_MASK		0X0f00
 #define BITS_DATA_5		0X0500
 #define BITS_DATA_6		0X0600
 #define BITS_DATA_7		0X0700
 #define BITS_DATA_8		0X0800
-#define BITS_DATA_9		0X0900
 
-#define BITS_PARITY_MASK	0x00f0
 #define BITS_PARITY_NONE	0x0000
 #define BITS_PARITY_ODD		0x0010
 #define BITS_PARITY_EVEN	0x0020
-#define BITS_PARITY_MARK	0x0030
-#define BITS_PARITY_SPACE	0x0040
 
-#define BITS_STOP_MASK		0x000f
 #define BITS_STOP_1		0x0000
-#define BITS_STOP_1_5		0x0001
 #define BITS_STOP_2		0x0002
 
 // CP210X_VENDOR_SPECIFIC values
@@ -156,7 +147,9 @@ boolean CUSBSerialCP2102Device::SetBaudRate (unsigned nBaudRate)
 	return TRUE;
 }
 
-boolean CUSBSerialCP2102Device::SetLineProperties (TUSBSerialDataBits nDataBits, TUSBSerialParity nParity, TUSBSerialStopBits nStopBits)
+boolean CUSBSerialCP2102Device::SetLineProperties (TUSBSerialDataBits nDataBits,
+						   TUSBSerialParity nParity,
+						   TUSBSerialStopBits nStopBits)
 {
 	CUSBHostController *pHost = GetHost ();
 	assert (pHost != 0);

--- a/lib/usb/usbserialcp2102.cpp
+++ b/lib/usb/usbserialcp2102.cpp
@@ -175,19 +175,19 @@ boolean CUSBSerialCP2102Device::SetLineProperties (TUSBSerialDataBits nDataBits,
 		return FALSE;
 		break;
 	}
-	framing.Format("%d", nDataBits);
+	framing.Format ("%d", nDataBits);
 
 	switch (nParity) {
 	case USBSerialParityNone:
-		framing.Append("N");
+		framing.Append ("N");
 		break;
 	case USBSerialParityOdd:
 		lcr |= BITS_PARITY_ODD;
-		framing.Append("O");
+		framing.Append ("O");
 		break;
 	case USBSerialParityEven:
 		lcr |= BITS_PARITY_EVEN;
-		framing.Append("E");
+		framing.Append ("E");
 		break;
 	default:
 		CLogger::Get ()->Write (FromCp2102, LogError, "Invalid parity %d", nParity);
@@ -197,11 +197,11 @@ boolean CUSBSerialCP2102Device::SetLineProperties (TUSBSerialDataBits nDataBits,
 
 	switch (nStopBits) {
 	case USBSerialStopBits1:
-		framing.Append("1");
+		framing.Append ("1");
 		break;
 	case USBSerialStopBits2:
 		lcr |= BITS_STOP_2;
-		framing.Append("2");
+		framing.Append ("2");
 		break;
 	default:
 		CLogger::Get ()->Write (FromCp2102, LogError, "Invalid stop bits %d", nStopBits);

--- a/lib/usb/usbserialcp2102.cpp
+++ b/lib/usb/usbserialcp2102.cpp
@@ -1,0 +1,249 @@
+//
+// usbserialcp2102.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2020  H. Kocevar <hinxx@protonmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <circle/usb/usbserialcp2102.h>
+#include <circle/usb/usbhostcontroller.h>
+#include <circle/devicenameservice.h>
+#include <circle/synchronize.h>
+#include <circle/logger.h>
+#include <assert.h>
+
+static const char FromCp2102[] = "cp2102";
+
+#define DEFAULT_BAUD_RATE	9600
+
+// Config request codes
+#define CP210X_IFC_ENABLE	0x00
+#define CP210X_SET_LINE_CTL	0x03
+#define CP210X_GET_LINE_CTL	0x04
+#define CP210X_GET_BAUDRATE	0x1D
+#define CP210X_SET_BAUDRATE	0x1E
+#define CP210X_VENDOR_SPECIFIC	0xFF
+
+// CP210X_IFC_ENABLE
+#define UART_ENABLE		0x0001
+#define UART_DISABLE		0x0000
+
+// CP210X_(SET|GET)_LINE_CTL
+#define BITS_DATA_MASK		0X0f00
+#define BITS_DATA_5		0X0500
+#define BITS_DATA_6		0X0600
+#define BITS_DATA_7		0X0700
+#define BITS_DATA_8		0X0800
+#define BITS_DATA_9		0X0900
+
+#define BITS_PARITY_MASK	0x00f0
+#define BITS_PARITY_NONE	0x0000
+#define BITS_PARITY_ODD		0x0010
+#define BITS_PARITY_EVEN	0x0020
+#define BITS_PARITY_MARK	0x0030
+#define BITS_PARITY_SPACE	0x0040
+
+#define BITS_STOP_MASK		0x000f
+#define BITS_STOP_1		0x0000
+#define BITS_STOP_1_5		0x0001
+#define BITS_STOP_2		0x0002
+
+// CP210X_VENDOR_SPECIFIC values
+#define CP210X_GET_PARTNUM	0x370B
+
+// Supported part number
+#define CP210X_PARTNUM_CP2102	0x02
+
+CUSBSerialCP2102Device::CUSBSerialCP2102Device (CUSBFunction *pFunction)
+:	CUSBSerialDevice (pFunction)
+{
+}
+
+CUSBSerialCP2102Device::~CUSBSerialCP2102Device (void)
+{
+}
+
+boolean CUSBSerialCP2102Device::Configure (void)
+{
+	if (!CUSBSerialDevice::Configure ())
+	{
+		CLogger::Get ()->Write (FromCp2102, LogError, "Cannot configure serial device");
+
+		return FALSE;
+	}
+
+	CUSBHostController *pHost = GetHost ();
+	assert (pHost != 0);
+
+	DMA_BUFFER (u8, rxData, 2) = {0};
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_IN | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   CP210X_VENDOR_SPECIFIC,
+				   CP210X_GET_PARTNUM,
+				   0,
+				   rxData, 1) != (int) 1)
+	{
+		CLogger::Get ()->Write (FromCp2102, LogError, "Cannot get part number byte");
+
+		return FALSE;
+	}
+	if (rxData[0] != CP210X_PARTNUM_CP2102)
+	{
+		CLogger::Get ()->Write (FromCp2102, LogError, "Unsupported part number");
+
+		return FALSE;
+	}
+	CLogger::Get ()->Write (FromCp2102, LogNotice, "Part number: CP210%d", rxData[0]);
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_INTERFACE,
+				   CP210X_IFC_ENABLE,
+				   UART_ENABLE,
+				   0,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromCp2102, LogError, "Cannot enable serial port");
+
+		return FALSE;
+	}
+	//CLogger::Get ()->Write (FromCp2102, LogDebug, "Serial port enabled!");
+
+	if (!SetBaudRate (DEFAULT_BAUD_RATE))
+	{
+		return FALSE;
+	}
+
+	if (!SetLineProperties (USBSerialDataBits8, USBSerialParityNone, USBSerialStopBits1))
+	{
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+boolean CUSBSerialCP2102Device::SetBaudRate (unsigned nBaudRate)
+{
+	CUSBHostController *pHost = GetHost ();
+	assert (pHost != 0);
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_INTERFACE,
+				   CP210X_SET_BAUDRATE,
+				   0,
+				   0,
+				   &nBaudRate, 4) < 0)
+	{
+		CLogger::Get ()->Write (FromCp2102, LogError, "Cannot set baud rate");
+
+		return FALSE;
+	}
+
+	m_nBaudRate = nBaudRate;
+	CLogger::Get ()->Write (FromCp2102, LogDebug, "Baud rate %d", m_nBaudRate);
+
+	return TRUE;
+}
+
+boolean CUSBSerialCP2102Device::SetLineProperties (TUSBSerialDataBits nDataBits, TUSBSerialParity nParity, TUSBSerialStopBits nStopBits)
+{
+	CUSBHostController *pHost = GetHost ();
+	assert (pHost != 0);
+
+	CString framing;
+	u16 lcr = 0;
+
+	switch (nDataBits) {
+	case USBSerialDataBits5:
+		lcr |= BITS_DATA_5;
+		break;
+	case USBSerialDataBits6:
+		lcr |= BITS_DATA_6;
+		break;
+	case USBSerialDataBits7:
+		lcr |= BITS_DATA_7;
+		break;
+	case USBSerialDataBits8:
+		lcr |= BITS_DATA_8;
+		break;
+	default:
+		CLogger::Get ()->Write (FromCp2102, LogError, "Invalid data bits %d", nDataBits);
+		return FALSE;
+		break;
+	}
+	framing.Format("%d", nDataBits);
+
+	switch (nParity) {
+	case USBSerialParityNone:
+		framing.Append("N");
+		break;
+	case USBSerialParityOdd:
+		lcr |= BITS_PARITY_ODD;
+		framing.Append("O");
+		break;
+	case USBSerialParityEven:
+		lcr |= BITS_PARITY_EVEN;
+		framing.Append("E");
+		break;
+	default:
+		CLogger::Get ()->Write (FromCp2102, LogError, "Invalid parity %d", nParity);
+		return FALSE;
+		break;
+	}
+
+	switch (nStopBits) {
+	case USBSerialStopBits1:
+		framing.Append("1");
+		break;
+	case USBSerialStopBits2:
+		lcr |= BITS_STOP_2;
+		framing.Append("2");
+		break;
+	default:
+		CLogger::Get ()->Write (FromCp2102, LogError, "Invalid stop bits %d", nStopBits);
+		return FALSE;
+		break;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_INTERFACE,
+				   CP210X_SET_LINE_CTL,
+				   lcr,
+				   0,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromCp2102, LogError, "Cannot set line properties");
+
+		return FALSE;
+	}
+
+	m_nDataBits = nDataBits;
+	m_nParity = nParity;
+	m_nStopBits = nStopBits;
+
+	//CLogger::Get ()->Write (FromCp2102, LogDebug, "Framing %s", (const char *)framing);
+
+	return TRUE;
+}
+
+const TUSBDeviceID *CUSBSerialCP2102Device::GetDeviceIDTable (void)
+{
+	static const TUSBDeviceID DeviceIDTable[] =
+	{
+		{ USB_DEVICE (0x10C4, 0xEA60) },
+		{ }
+	};
+
+	return DeviceIDTable;
+}

--- a/lib/usb/usbserialft231x.cpp
+++ b/lib/usb/usbserialft231x.cpp
@@ -1,0 +1,264 @@
+//
+// usbserialft231x.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2020  H. Kocevar <hinxx@protonmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <circle/usb/usbserialft231x.h>
+#include <circle/usb/usbhostcontroller.h>
+#include <circle/devicenameservice.h>
+#include <circle/synchronize.h>
+#include <circle/util.h>
+#include <circle/logger.h>
+#include <assert.h>
+
+static const char FromFt231x[] = "ft231x";
+
+#define DEFAULT_BAUD_RATE		9600
+
+#define FTDI_SIO_GET_LATENCY_TIMER	10
+#define FTDI_SIO_RESET			0
+#define FTDI_SIO_RESET_SIO		0x0
+#define FTDI_SIO_SET_FLOW_CTRL		2
+#define FTDI_SIO_DISABLE_FLOW_CTRL	0x0
+#define FTDI_SIO_SET_BAUD_RATE		3
+#define FTDI_SIO_SET_DATA		4
+#define FTDI_SIO_SET_DATA_PARITY_NONE	(0x0 << 8)
+#define FTDI_SIO_SET_DATA_PARITY_ODD	(0x1 << 8)
+#define FTDI_SIO_SET_DATA_PARITY_EVEN	(0x2 << 8)
+#define FTDI_SIO_SET_DATA_STOP_BITS_1	(0x0 << 11)
+#define FTDI_SIO_SET_DATA_STOP_BITS_2	(0x2 << 11)
+
+CUSBSerialFT231XDevice::CUSBSerialFT231XDevice (CUSBFunction *pFunction)
+:	CUSBSerialDevice (pFunction)
+{
+}
+
+CUSBSerialFT231XDevice::~CUSBSerialFT231XDevice (void)
+{
+}
+
+boolean CUSBSerialFT231XDevice::Configure (void)
+{
+	if (!CUSBSerialDevice::Configure ())
+	{
+		CLogger::Get ()->Write (FromFt231x, LogError, "Cannot configure serial device");
+
+		return FALSE;
+	}
+
+	CUSBDevice *device = GetDevice ();
+	const TUSBDeviceDescriptor *deviceDesc = device->GetDeviceDescriptor ();
+	CString type = "??";
+	if (deviceDesc->bcdDevice == 0x1000)
+	{
+		type = "FT-X";
+	}
+	CLogger::Get ()->Write (FromFt231x, LogNotice, "Part number: %s", (const char *)type);
+
+	CUSBHostController *pHost = GetHost ();
+	assert (pHost != 0);
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   FTDI_SIO_RESET,
+				   0,
+				   0,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromFt231x, LogError, "Cannot reset device");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   FTDI_SIO_SET_FLOW_CTRL,
+				   0,
+				   0,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromFt231x, LogError, "Cannot disable flow control");
+
+		return FALSE;
+	}
+
+	if (!SetBaudRate (DEFAULT_BAUD_RATE))
+	{
+		return FALSE;
+	}
+
+	if (!SetLineProperties (USBSerialDataBits8, USBSerialParityNone, USBSerialStopBits1))
+	{
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+boolean CUSBSerialFT231XDevice::SetBaudRate (unsigned nBaudRate)
+{
+	CUSBHostController *pHost = GetHost ();
+	assert (pHost != 0);
+
+	const int base = 48000000;
+	const u8 divfrac[8] = { 0, 3, 2, 4, 1, 5, 6, 7 };
+	u32 divisor;
+	// divisor shifted 3 bits to the left
+	int divisor3 = base / 2 / nBaudRate;
+	divisor = divisor3 >> 3;
+	divisor |= (u32) divfrac[divisor3 & 0x7] << 14;
+	// deal with special cases for highest baud rates
+	if (divisor == 1)
+		divisor = 0;
+	else if (divisor == 0x4001)
+		divisor = 1;
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   FTDI_SIO_SET_BAUD_RATE,
+				   (u16) divisor,
+				   (u16) (divisor >> 16),
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromFt231x, LogError, "Cannot set baud rate");
+
+		return FALSE;
+	}
+
+	m_nBaudRate = nBaudRate;
+	CLogger::Get ()->Write (FromFt231x, LogDebug, "Baud rate %d", m_nBaudRate);
+
+	return TRUE;
+}
+
+boolean CUSBSerialFT231XDevice::SetLineProperties (TUSBSerialDataBits nDataBits,
+						   TUSBSerialParity nParity,
+						   TUSBSerialStopBits nStopBits)
+{
+	CUSBHostController *pHost = GetHost ();
+	assert (pHost != 0);
+
+	CString framing;
+	u16 lcr = 0;
+
+	switch (nDataBits) {
+	case USBSerialDataBits5:
+	case USBSerialDataBits6:
+		CLogger::Get ()->Write (FromFt231x, LogError, "Unsupported data bits %d", nDataBits);
+		return FALSE;
+		break;
+	case USBSerialDataBits7:
+		lcr |= 7;
+		break;
+	case USBSerialDataBits8:
+		lcr |= 8;
+		break;
+	default:
+		CLogger::Get ()->Write (FromFt231x, LogError, "Unsupported data bits %d", nDataBits);
+		return FALSE;
+		break;
+	}
+	framing.Format ("%d", nDataBits);
+
+	switch (nParity) {
+	case USBSerialParityNone:
+		lcr |= FTDI_SIO_SET_DATA_PARITY_NONE;
+		framing.Append ("N");
+		break;
+	case USBSerialParityOdd:
+		lcr |= FTDI_SIO_SET_DATA_PARITY_ODD;
+		framing.Append ("O");
+		break;
+	case USBSerialParityEven:
+		lcr |= FTDI_SIO_SET_DATA_PARITY_EVEN;
+		framing.Append ("E");
+		break;
+	default:
+		CLogger::Get ()->Write (FromFt231x, LogError, "Invalid parity %d", nParity);
+		return FALSE;
+		break;
+	}
+
+	switch (nStopBits) {
+	case USBSerialStopBits1:
+		lcr |= FTDI_SIO_SET_DATA_STOP_BITS_1;
+		framing.Append ("1");
+		break;
+	case USBSerialStopBits2:
+		lcr |= FTDI_SIO_SET_DATA_STOP_BITS_2;
+		framing.Append ("2");
+		break;
+	default:
+		CLogger::Get ()->Write (FromFt231x, LogError, "Invalid stop bits %d", nStopBits);
+		return FALSE;
+		break;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   FTDI_SIO_SET_DATA,
+				   lcr,
+				   0,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromFt231x, LogError, "Cannot set line properties");
+
+		return FALSE;
+	}
+
+	m_nDataBits = nDataBits;
+	m_nParity = nParity;
+	m_nStopBits = nStopBits;
+
+	CLogger::Get ()->Write (FromFt231x, LogDebug, "Framing %s", (const char *)framing);
+
+	return TRUE;
+}
+
+int CUSBSerialFT231XDevice::Read (void *pBuffer, size_t nCount)
+{
+	assert (pBuffer != 0);
+	assert (nCount > 0);
+
+	int nActual = CUSBSerialDevice::Read (pBuffer, nCount);
+	if (nActual < 0)
+	{
+		return -1;
+	}
+
+	assert (nActual > 0);
+	nActual -= 2;
+	if (nActual > 0)
+	{
+		memmove (pBuffer, (u8 *)pBuffer + 2, nActual);
+	}
+
+	//CLogger::Get ()->Write (FromFt231x, LogDebug, "Read() want %d, returned %d", nCount, nActual);
+
+	return nActual;
+}
+
+const TUSBDeviceID *CUSBSerialFT231XDevice::GetDeviceIDTable (void)
+{
+	static const TUSBDeviceID DeviceIDTable[] =
+	{
+		{ USB_DEVICE (0x0403, 0x6015) },
+		{ }
+	};
+
+	return DeviceIDTable;
+}

--- a/lib/usb/usbserialpl2303.cpp
+++ b/lib/usb/usbserialpl2303.cpp
@@ -263,7 +263,8 @@ boolean CUSBSerialPL2303Device::SetBaudRate (unsigned nBaudRate)
 	}
 
 	m_nBaudRate = nBaudRate;
-	CLogger::Get ()->Write (FromPl2303, LogDebug, "Baud rate %d", m_nBaudRate);
+
+	//CLogger::Get ()->Write (FromPl2303, LogDebug, "Baud rate %d", m_nBaudRate);
 
 	return TRUE;
 }
@@ -360,7 +361,7 @@ boolean CUSBSerialPL2303Device::SetLineProperties (TUSBSerialDataBits nDataBits,
 	m_nParity = nParity;
 	m_nStopBits = nStopBits;
 
-	CLogger::Get ()->Write (FromPl2303, LogDebug, "Framing %s", (const char *)framing);
+	//CLogger::Get ()->Write (FromPl2303, LogDebug, "Framing %s", (const char *)framing);
 
 	return TRUE;
 }

--- a/lib/usb/usbserialpl2303.cpp
+++ b/lib/usb/usbserialpl2303.cpp
@@ -53,8 +53,8 @@ boolean CUSBSerialPL2303Device::Configure (void)
 		return FALSE;
 	}
 
-	CUSBDevice *device = GetDevice();
-	const TUSBDeviceDescriptor *deviceDesc = device->GetDeviceDescriptor();
+	CUSBDevice *device = GetDevice ();
+	const TUSBDeviceDescriptor *deviceDesc = device->GetDeviceDescriptor ();
 	CString type = "0";
 	if (deviceDesc->bDeviceClass == 0x02)
 	{
@@ -249,7 +249,7 @@ boolean CUSBSerialPL2303Device::SetBaudRate (unsigned nBaudRate)
 		return FALSE;
 	}
 
-	memcpy(rxData, (u8 *)&nBaudRate, 4);
+	memcpy (rxData, (u8 *) &nBaudRate, 4);
 	if (pHost->ControlMessage (GetEndpoint0 (),
 				   REQUEST_OUT | REQUEST_CLASS | REQUEST_TO_INTERFACE,
 				   SET_LINE_REQUEST,
@@ -309,20 +309,20 @@ boolean CUSBSerialPL2303Device::SetLineProperties (TUSBSerialDataBits nDataBits,
 		return FALSE;
 		break;
 	}
-	framing.Format("%d", nDataBits);
+	framing.Format ("%d", nDataBits);
 
 	switch (nParity) {
 	case USBSerialParityNone:
 		rxData[5] = 0;
-		framing.Append("N");
+		framing.Append ("N");
 		break;
 	case USBSerialParityOdd:
 		rxData[5] = 1;
-		framing.Append("O");
+		framing.Append ("O");
 		break;
 	case USBSerialParityEven:
 		rxData[5] = 2;
-		framing.Append("E");
+		framing.Append ("E");
 		break;
 	default:
 		CLogger::Get ()->Write (FromPl2303, LogError, "Invalid parity %d", nParity);
@@ -333,11 +333,11 @@ boolean CUSBSerialPL2303Device::SetLineProperties (TUSBSerialDataBits nDataBits,
 	switch (nStopBits) {
 	case USBSerialStopBits1:
 		rxData[4] = 0;
-		framing.Append("1");
+		framing.Append ("1");
 		break;
 	case USBSerialStopBits2:
 		rxData[4] = 2;
-		framing.Append("2");
+		framing.Append ("2");
 		break;
 	default:
 		CLogger::Get ()->Write (FromPl2303, LogError, "Invalid stop bits %d", nStopBits);

--- a/lib/usb/usbserialpl2303.cpp
+++ b/lib/usb/usbserialpl2303.cpp
@@ -1,0 +1,377 @@
+//
+// usbserialpl2303.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2020  H. Kocevar <hinxx@protonmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <circle/usb/usbserialpl2303.h>
+#include <circle/usb/usbhostcontroller.h>
+#include <circle/devicenameservice.h>
+#include <circle/synchronize.h>
+#include <circle/util.h>
+#include <circle/logger.h>
+#include <assert.h>
+
+static const char FromPl2303[] = "pl2303";
+
+#define DEFAULT_BAUD_RATE	9600
+
+// Config request codes
+#define VENDOR_READ_REQUEST	0x01
+#define VENDOR_WRITE_REQUEST	0x01
+#define GET_LINE_REQUEST	0x21
+#define SET_LINE_REQUEST	0x20
+
+CUSBSerialPL2303Device::CUSBSerialPL2303Device (CUSBFunction *pFunction)
+:	CUSBSerialDevice (pFunction)
+{
+}
+
+CUSBSerialPL2303Device::~CUSBSerialPL2303Device (void)
+{
+}
+
+boolean CUSBSerialPL2303Device::Configure (void)
+{
+	if (!CUSBSerialDevice::Configure ())
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot configure serial device");
+
+		return FALSE;
+	}
+
+	CUSBDevice *device = GetDevice();
+	const TUSBDeviceDescriptor *deviceDesc = device->GetDeviceDescriptor();
+	CString type = "0";
+	if (deviceDesc->bDeviceClass == 0x02)
+	{
+		type = "0";
+	}
+	else if (deviceDesc->bMaxPacketSize0 == 0x40)
+	{
+		type = "HX";
+	}
+	else if (deviceDesc->bDeviceClass == 0x00 || deviceDesc->bDeviceClass == 0xFF)
+	{
+		type = "1";
+	}
+	CLogger::Get ()->Write (FromPl2303, LogNotice, "Part number: PL2303 type %s", (const char *)type);
+
+	CUSBHostController *pHost = GetHost ();
+	assert (pHost != 0);
+
+	DMA_BUFFER (u8, rxData, 1) = {0};
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_IN | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_READ_REQUEST,
+				   0x8484,
+				   0,
+				   rxData, 1) != (int) 1)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot read 0x8484");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_WRITE_REQUEST,
+				   0x0404,
+				   0,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot write 0x0404");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_IN | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_READ_REQUEST,
+				   0x8484,
+				   0,
+				   rxData, 1) != (int) 1)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot read 0x8484");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_IN | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_READ_REQUEST,
+				   0x8383,
+				   0,
+				   rxData, 1) != (int) 1)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot read 0x8383");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_IN | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_READ_REQUEST,
+				   0x8484,
+				   0,
+				   rxData, 1) != (int) 1)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot read 0x8484");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_WRITE_REQUEST,
+				   0x0404,
+				   1,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot write 0x0404");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_IN | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_READ_REQUEST,
+				   0x8484,
+				   0,
+				   rxData, 1) != (int) 1)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot read 0x8484");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_IN | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_READ_REQUEST,
+				   0x8383,
+				   0,
+				   rxData, 1) != (int) 1)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot read 0x8383");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_WRITE_REQUEST,
+				   0,
+				   1,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot write 0");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_WRITE_REQUEST,
+				   1,
+				   0,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot write 1");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_WRITE_REQUEST,
+				   2,
+				   0x44,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot write 2");
+
+		return FALSE;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_VENDOR | REQUEST_TO_DEVICE,
+				   VENDOR_WRITE_REQUEST,
+				   0,
+				   0,
+				   0, 0) < 0)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot write 0");
+
+		return FALSE;
+	}
+
+	if (!SetBaudRate (DEFAULT_BAUD_RATE))
+	{
+		return FALSE;
+	}
+
+	if (!SetLineProperties (USBSerialDataBits8, USBSerialParityNone, USBSerialStopBits1))
+	{
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+boolean CUSBSerialPL2303Device::SetBaudRate (unsigned nBaudRate)
+{
+	CUSBHostController *pHost = GetHost ();
+	assert (pHost != 0);
+
+	DMA_BUFFER (u8, rxData, 7) = {0};
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_IN | REQUEST_CLASS | REQUEST_TO_INTERFACE,
+				   GET_LINE_REQUEST,
+				   0,
+				   0,
+				   rxData, 7) != (int) 7)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot get baud rate");
+
+		return FALSE;
+	}
+
+	memcpy(rxData, (u8 *)&nBaudRate, 4);
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_CLASS | REQUEST_TO_INTERFACE,
+				   SET_LINE_REQUEST,
+				   0,
+				   0,
+				   rxData, 7) < 0)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot set baud rate");
+
+		return FALSE;
+	}
+
+	m_nBaudRate = nBaudRate;
+	CLogger::Get ()->Write (FromPl2303, LogDebug, "Baud rate %d", m_nBaudRate);
+
+	return TRUE;
+}
+
+boolean CUSBSerialPL2303Device::SetLineProperties (TUSBSerialDataBits nDataBits,
+						   TUSBSerialParity nParity,
+						   TUSBSerialStopBits nStopBits)
+{
+	CUSBHostController *pHost = GetHost ();
+	assert (pHost != 0);
+
+	DMA_BUFFER (u8, rxData, 7) = {0};
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_IN | REQUEST_CLASS | REQUEST_TO_INTERFACE,
+				   GET_LINE_REQUEST,
+				   0,
+				   0,
+				   rxData, 7) != (int) 7)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot get line properties");
+
+		return FALSE;
+	}
+
+	CString framing;
+
+	switch (nDataBits) {
+	case USBSerialDataBits5:
+		rxData[6] = 5;
+		break;
+	case USBSerialDataBits6:
+		rxData[6] = 6;
+		break;
+	case USBSerialDataBits7:
+		rxData[6] = 7;
+		break;
+	case USBSerialDataBits8:
+		rxData[6] = 8;
+		break;
+	default:
+		CLogger::Get ()->Write (FromPl2303, LogError, "Invalid data bits %d", nDataBits);
+		return FALSE;
+		break;
+	}
+	framing.Format("%d", nDataBits);
+
+	switch (nParity) {
+	case USBSerialParityNone:
+		rxData[5] = 0;
+		framing.Append("N");
+		break;
+	case USBSerialParityOdd:
+		rxData[5] = 1;
+		framing.Append("O");
+		break;
+	case USBSerialParityEven:
+		rxData[5] = 2;
+		framing.Append("E");
+		break;
+	default:
+		CLogger::Get ()->Write (FromPl2303, LogError, "Invalid parity %d", nParity);
+		return FALSE;
+		break;
+	}
+
+	switch (nStopBits) {
+	case USBSerialStopBits1:
+		rxData[4] = 0;
+		framing.Append("1");
+		break;
+	case USBSerialStopBits2:
+		rxData[4] = 2;
+		framing.Append("2");
+		break;
+	default:
+		CLogger::Get ()->Write (FromPl2303, LogError, "Invalid stop bits %d", nStopBits);
+		return FALSE;
+		break;
+	}
+
+	if (pHost->ControlMessage (GetEndpoint0 (),
+				   REQUEST_OUT | REQUEST_CLASS | REQUEST_TO_INTERFACE,
+				   SET_LINE_REQUEST,
+				   0,
+				   0,
+				   rxData, 7) < 0)
+	{
+		CLogger::Get ()->Write (FromPl2303, LogError, "Cannot set line properties");
+
+		return FALSE;
+	}
+
+	m_nDataBits = nDataBits;
+	m_nParity = nParity;
+	m_nStopBits = nStopBits;
+
+	CLogger::Get ()->Write (FromPl2303, LogDebug, "Framing %s", (const char *)framing);
+
+	return TRUE;
+}
+
+const TUSBDeviceID *CUSBSerialPL2303Device::GetDeviceIDTable (void)
+{
+	static const TUSBDeviceID DeviceIDTable[] =
+	{
+		{ USB_DEVICE (0x067B, 0x2303) },
+		{ }
+	};
+
+	return DeviceIDTable;
+}


### PR DESCRIPTION
New set of improvements and additions to the USB to serial code. Based on Circle upstream `usb-serial` branch.

Created RTK.GPIO class that abstracts low-level detail of GPIO handling from the end user. Refactored the existing sample. Tested with the RTK.GPIO board.

Added CP2102 USB to serial driver that derives the _CUSBSerialDevice_.
