### PR TITLE
soundbasedevice: Allow fast path for same formats

### DIFF
--- a/lib/soundbasedevice.cpp
+++ b/lib/soundbasedevice.cpp
@@ -147,12 +147,11 @@ int CSoundBaseDevice::Write (const void *pBuffer, size_t nCount)
 
 	m_SpinLock.Acquire ();
 
-	if (   m_HWFormat == SoundFormatSigned16
-	    && m_WriteFormat == SoundFormatSigned16
+	if (   m_HWFormat == m_WriteFormat
 	    && m_nWriteChannels == SOUND_HW_CHANNELS
 	    && !m_bSwapChannels)
 	{
-		// fast path for SoundFormatSigned16 Stereo without conversion
+		// fast path for Stereo samples without bit depth conversion or channel swapping
 
 		unsigned nBytes = GetQueueBytesFree ();
 		if (nBytes > nCount)


### PR DESCRIPTION
This is a trivial change that I hope makes sense!

The idea is that I wanted to be able to write into the queue of SoundBaseDevice as quickly as possible and avoid unnecessary conversion via `ConvertSoundFormat()`.

I have synthesizers that output floating-point samples, and in my kernel I convert these directly to 24-bit signed integers suitable for I2S DACs, and enqueue them.

With this change, the same "fast path" as defined for `SoundFormatSigned16` is generalized so that it applies whenever the write format matches the hardware format.