### PR TITLE
soundbasedevice: Allow queue allocation in frames

### DIFF
--- a/include/circle/soundbasedevice.h
+++ b/include/circle/soundbasedevice.h
@@ -84,6 +84,11 @@ public:
 	/// \note Not used, if GetChunk() is overloaded.
 	boolean AllocateQueue (unsigned nSizeMsecs);
 
+	/// \brief Allocate the queue used for Write()
+	/// \param nSizeMsecs Size of the queue in frames of audio
+	/// \note Not used, if GetChunk() is overloaded.
+	boolean AllocateQueueFrames (unsigned nSizeFrames);
+
 	/// \param Format    Format of sound data used for Write()
 	/// \param nChannels 1 or 2 channels
 	/// \note Not used, if GetChunk() is overloaded.

--- a/lib/soundbasedevice.cpp
+++ b/lib/soundbasedevice.cpp
@@ -106,6 +106,25 @@ boolean CSoundBaseDevice::AllocateQueue (unsigned nSizeMsecs)
 	return TRUE;
 }
 
+boolean CSoundBaseDevice::AllocateQueueFrames (unsigned nSizeFrames)
+{
+	assert (m_pQueue == 0);
+	assert (1 <= nSizeFrames && nSizeFrames <= m_nSampleRate);
+
+	// 1 byte remains free
+	m_nQueueSize = m_nHWFrameSize*nSizeFrames + 1;
+
+	m_pQueue = new u8[m_nQueueSize];
+	if (m_pQueue == 0)
+	{
+		return FALSE;
+	}
+
+	m_nNeedDataThreshold = m_nQueueSize / 2;
+
+	return TRUE;
+}
+
 void CSoundBaseDevice::SetWriteFormat (TSoundFormat Format, unsigned nChannels)
 {
 	assert (Format < SoundFormatUnknown);


### PR DESCRIPTION
Currently, `SoundBaseDevice` is limited because we can only allocate queues in terms of milliseconds.

For projects that want to have more precise control of the queue size (e.g. to reduce audio latency to an absolute minimum) it would be ideal to be able to allocate a sound queue in terms of frames. In my project, I am able to run reliably with the queue size equal to the chunk size (i.e. just one chunk in the queue), and a dedicated core rendering audio into the queue.

This PR may not be the cleanest way to do this as it just adds a new function and most of the code is just a copy of `AllocateQueueFrames()`, so if you can think of a better way to achieve this, I'd be more than happy to refine the PR! 

Thanks!