### PR TITLE
Add option to allow I2S DAC to be master clock

### DIFF
--- a/include/circle/i2ssoundbasedevice.h
+++ b/include/circle/i2ssoundbasedevice.h
@@ -45,9 +45,11 @@ public:
 	/// \param nSampleRate	sample rate in Hz
 	/// \param nChunkSize	twice the number of samples (words) to be handled\n
 	///			with one call to GetChunk() (one word per stereo channel)
+	/// \param bSlave		enable slave mode (PCM clock and FS clock are inputs)
 	CI2SSoundBaseDevice (CInterruptSystem *pInterrupt,
 			     unsigned	       nSampleRate = 192000,
-			     unsigned	       nChunkSize  = 8192);
+			     unsigned	       nChunkSize  = 8192,
+			     bool		       bSlave      = FALSE);
 
 	virtual ~CI2SSoundBaseDevice (void);
 
@@ -90,6 +92,7 @@ private:
 private:
 	CInterruptSystem *m_pInterruptSystem;
 	unsigned m_nChunkSize;
+	bool     m_bSlave;
 
 	CGPIOPin   m_PCMCLKPin;
 	CGPIOPin   m_PCMFSPin;


### PR DESCRIPTION
Hi!

With this patch, it becomes possible to use DACs that generate their own I2S clocks. The example I have been testing is the Blokas Pisound, which has an ADC (recording device) on-board, and seems to be wired such that the ADC provides the master clock.

Hence, to use this DAC, the Pi's I2S device must be configured to be a slave.

Apologies if the tab size is incorrect, I've tried to follow your indentation style - it seems to be correct if the tab size is 4. 🙂