### PR TITLE
addon/SDCard: Enable optional High Speed/SDR25 mode

### DIFF
--- a/addon/SDCard/emmc.cpp
+++ b/addon/SDCard/emmc.cpp
@@ -68,6 +68,9 @@
 // Enable 1.8V support
 //#define SD_1_8V_SUPPORT
 
+// Enable High Speed/SDR25 mode
+//#define SD_HIGH_SPEED
+
 // Enable 4-bit support
 #define SD_4BIT_DATA
 
@@ -277,7 +280,7 @@ const u32 CEMMCDevice::sd_commands[] =
 	SD_CMD_INDEX(3) | SD_RESP_R6,
 	SD_CMD_INDEX(4),
 	SD_CMD_INDEX(5) | SD_RESP_R4,
-	SD_CMD_INDEX(6) | SD_RESP_R1,
+	SD_CMD_INDEX(6) | SD_RESP_R1 | SD_DATA_READ,
 	SD_CMD_INDEX(7) | SD_RESP_R1b,
 	SD_CMD_INDEX(8) | SD_RESP_R7,
 	SD_CMD_INDEX(9) | SD_RESP_R2,
@@ -1511,6 +1514,7 @@ int CEMMCDevice::CardReset (void)
 	m_device_id[3] = 0;
 
 	m_card_supports_sdhc = 0;
+	m_card_supports_hs = 0;
 	m_card_supports_18v = 0;
 	m_card_ocr = 0;
 	m_card_rca = 0;
@@ -1955,6 +1959,57 @@ int CEMMCDevice::CardReset (void)
 	LogWrite (LogDebug, "SCR[0]: %08x, SCR[1]: %08x", m_pSCR->scr[0], m_pSCR->scr[1]);;
 	LogWrite (LogDebug, "SCR: %08x%08x", be2le32(m_pSCR->scr[0]), be2le32(m_pSCR->scr[1]));
 	LogWrite (LogDebug, "SCR: version %s, bus_widths %01x", sd_versions[m_pSCR->sd_version], m_pSCR->sd_bus_widths);
+#endif
+
+#ifdef SD_HIGH_SPEED
+	// If card supports CMD6, read switch information from card
+	if (m_pSCR->sd_version >= SD_VER_1_1)
+	{
+		// 512 bit response
+		u8 cmd6_resp[64];
+		m_buf = &cmd6_resp[0];
+		m_block_size = 64;
+
+		// CMD6 Mode 0: Check Function (Group 1, Access Mode)
+		if (!IssueCommand (SWITCH_FUNC, 0x00fffff0, 100000))
+		{
+			LogWrite (LogError, "Error sending SWITCH_FUNC (Mode 0)");
+		}
+		else
+		{
+			// Check Group 1, Function 1 (High Speed/SDR25)
+			m_card_supports_hs = (cmd6_resp[13] >> 1) & 0x1;
+
+			// Attempt switch if supported
+			if (m_card_supports_hs)
+			{
+#ifdef EMMC_DEBUG2
+				LogWrite (LogDebug, "Switching to %s mode", m_card_supports_18v ? "SDR25" : "High Speed");
+#endif
+
+				// CMD6 Mode 1: Set Function (Group 1, Access Mode = High Speed/SDR25)
+				if (!IssueCommand (SWITCH_FUNC, 0x80fffff1, 100000))
+				{
+					LogWrite (LogError, "Switch to %s mode failed", m_card_supports_18v ? "SDR25" : "High Speed");
+				}
+				else
+				{
+					// Success; switch clock to 50MHz
+#ifndef USE_SDHOST
+					SwitchClockRate (base_clock, SD_CLOCK_HIGH);
+#else
+					m_Host.SetClock (SD_CLOCK_HIGH);
+#endif
+#ifdef EMMC_DEBUG2
+					LogWrite (LogDebug, "Switch to 50MHz clock complete");
+#endif
+				}
+			}
+		}
+
+		// Restore block size
+		m_block_size = SD_BLOCK_SIZE;
+	}
 #endif
 
 	if (m_pSCR->sd_bus_widths & 4)

--- a/addon/SDCard/emmc.h
+++ b/addon/SDCard/emmc.h
@@ -128,6 +128,7 @@ private:
 	u32 m_device_id[4];
 
 	u32 m_card_supports_sdhc;
+	u32 m_card_supports_hs;
 	u32 m_card_supports_18v;
 	u32 m_card_ocr;
 	u32 m_card_rca;


### PR DESCRIPTION
As originally discussed in #172.

This commit enables an optional `SD_HIGH_SPEED` definition that, if enabled, will cause the EMMC driver to try to negotiate a higher clock speed. This should work for all combinations of EMMC/SDHOST driver configurations.

This is done by sending CMD6 in Mode 0 to read the supported access modes from the SD card. If the High Speed/SDR25 bit is enabled, call CMD6 again in Mode 1 to request that the SD card switch to this mode, and then switch the host clock rate to match if successful.

CMD6 is only supported by SD cards that support the Physical Layer Specification version 1.10 or above, so this procedure is wrapped in a version check (reading the version number that was received from the SCR register).

The [Linux driver](https://elixir.bootlin.com/linux/latest/source/drivers/mmc/core/sd.c#L1113) and the [Physical Layer Simplified Specification](https://www.sdcard.org/downloads/pls/click.php?p=Part1_Physical_Layer_Simplified_Specification_Ver8.00.jpg&f=Part1_Physical_Layer_Simplified_Specification_Ver8.00.pdf&e=EN_SS1_8) were used as references for implementing this behaviour.

1.8V mode operation has not been considered or tested, though if 1.8V mode was enabled for Pi 4 in a future commit, this code shouldn't need any changes - the clock speed change mechanism is pretty much the same, but it's called "SDR25" rather than "High Speed".

---

Not part of this PR is a simple test application that was used to test performance and reliability of this patch. Code for the test app is available here: https://github.com/dwhinham/circle/tree/sdcard-test

The test is not exhaustive or perfect, but gives a pretty good indication of stability. A variety of old and new SD cards were tested against Pi Zero W, Pi Model B, Pi 3A+, and Pi 4B. 

So far I have encountered no failures, which is reassuring. The code may even be safe to enable permanently as it's just doing a very similar thing to what Linux does, but perhaps more testing would be a good idea to confirm this.

Test description:

1. A 256MB file full of random data is created on a PC, using `dd if=/dev/urandom of=testfile.bin bs=1M count=256  status=progress`. This file is copied to the root of the SD card.
2. The SHA256 sum of the file is taken and noted: `sha256sum testfile.bin`
3. A kernel is compiled for the target Pi, first with `SD_HIGH_SPEED` undefined, and then with it defined (e.g. by adding `DEFINE += -DSD_HIGH_SPEED` into `Config.mk`).
4. The Pi runs the kernel, which then loads the entire 256MB file into memory, and performs a SHA256 hash on the data.
5. The kernel then writes the file from memory back to a new file, `testfile2.bin`.
6. The user verifies that the SHA256 hash was correct when the Pi read the file (by reading the kernel's log), and that the SHA256 hash of the `testfile2.bin` that was written by the Pi matches the original (by using a PC).

Test results:
![image](https://user-images.githubusercontent.com/5890747/103182033-b9415a80-489f-11eb-93aa-ac603a3dbc07.png)

Editable spreadsheet:
https://docs.google.com/spreadsheets/d/1nBtIlqOCRY-ZC1rlxMgWXzXILBHJniGg2TMiyOLvr70/edit?usp=sharing

Note that from the results, even with `SD_HIGH_SPEED` defined, cards that do not support High Speed mode (such as the SanDisk microSD 1GB) simply operate as normal at Default Speed.

I've attached binaries of the test app for convenience here with 32-bit kernels for Pi 0/1, 3, and 4:
[sdcard-test.zip](https://github.com/rsta2/circle/files/5745442/sdcard-test.zip)

All you have to do is create the test file (as described in step 1) and rename one of the kernel images. `_SLOW` kernels were compiled with `SD_HIGH_SPEED` **undefined**, `_FAST` kernels were compiled with `SD_HIGH_SPEED` **defined**.

I hope this makes sense and I'd be glad to make any corrections or respond to feedback.
Thanks for your consideration! 🙂