### PR TITLE
Fix the USB standard gamepad report decoding.

### DIFF
--- a/include/circle/usb/usbgamepadstandard.h
+++ b/include/circle/usb/usbgamepadstandard.h
@@ -38,10 +38,6 @@ protected:
 	void DecodeReport (const u8 *pReportBuffer);
 
 private:
-	static u32 BitGetUnsigned (const void *buffer, u32 offset, u32 length);
-	static s32 BitGetSigned (const void *buffer, u32 offset, u32 length);
-
-private:
 	boolean m_bAutoStartRequest;
 
 	u8 *m_pHIDReportDescriptor;

--- a/include/circle/usb/usbhiddevice.h
+++ b/include/circle/usb/usbhiddevice.h
@@ -53,6 +53,9 @@ protected:
 	int ReceiveFromEndpointIn (void *pBuffer, unsigned nBufSize,
 				   unsigned nTimeoutMs = USB_TIMEOUT_NONE);
 
+	u32 ExtractUnsigned (const void *buffer, u32 offset, u32 length);
+	s32 ExtractSigned (const void *buffer, u32 offset, u32 length);
+
 private:
 	void CompletionRoutine (CUSBRequest *pURB);
 	static void CompletionStub (CUSBRequest *pURB, void *pParam, void *pContext);

--- a/include/circle/usb/usbmouse.h
+++ b/include/circle/usb/usbmouse.h
@@ -58,8 +58,6 @@ public:
 private:
 	void ReportHandler (const u8 *pReport, unsigned nReportSize);
 	void DecodeReport (void);
-	u32 ExtractUnsigned (const void *buffer, u32 offset, u32 length);
-	s32 ExtractSigned (const void *buffer, u32 offset, u32 length);
 
 private:
 	CMouseDevice *m_pMouseDevice;

--- a/lib/usb/usbmouse.cpp
+++ b/lib/usb/usbmouse.cpp
@@ -167,60 +167,6 @@ void CUSBMouseDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)
 	}
 }
 
-u32 CUSBMouseDevice::ExtractUnsigned(const void *buffer, u32 offset, u32 length)
-{
-	assert(buffer != 0);
-	assert(length <= 32);
-
-	if (length == 0)
-	{
-		return 0;
-	}
-
-	u8 *bits = (u8 *)buffer;
-	unsigned shift = offset % 8;
-	offset = offset / 8;
-	bits = bits + offset;
-	unsigned number = *(unsigned *)bits;
-	offset = shift;
-
-	unsigned result = 0;
-	if (length > 24)
-	{
-		result = (((1 << 24) - 1) & (number >> offset));
-		bits = bits + 3;
-		number = *(unsigned *)bits;
-		length = length - 24;
-		unsigned result2 = (((1 << length) - 1) & (number >> offset));
-		result = (result2 << 24) | result;
-	}
-	else
-	{
-		result = (((1 << length) - 1) & (number >> offset));
-	}
-
-	return result;
-}
-
-s32 CUSBMouseDevice::ExtractSigned(const void *buffer, u32 offset, u32 length)
-{
-	assert(buffer != 0);
-	assert(length <= 32);
-
-	unsigned result = ExtractUnsigned(buffer, offset, length);
-	if ((length == 0) || (length == 32))
-	{
-		return result;
-	}
-
-	if (result & (1 << (length - 1)))
-	{
-		result |= 0xffffffff - ((1 << length) - 1);
-	}
-
-	return result;
-}
-
 void CUSBMouseDevice::DecodeReport (void)
 {
 	s32 item, arg;


### PR DESCRIPTION
Hi,

While using the great circle lib for my personnal project (Amstrad CPC emulator for bare-metal pi3/4), I encountered a problem using my gamepads : 
A kind of Generic gamepad was not working as expected. after some investigation, I found that the report decoding is not correct, when the bit size of a field is not a multiple of 8 (I have 4 and 12 bit size, here).
After some more investigation, I found a similar function, working correctly with the HID mouse. So, I suggest to use the same function for both.
It's the purpose of this pool request.

Kind regards,
