### PR TITLE
Fix for CTask::WaitForTermination when task has been deleted by scheduler

### DIFF
--- a/include/circle/sched/scheduler.h
+++ b/include/circle/sched/scheduler.h
@@ -39,6 +39,7 @@ public:
 	void usSleep (unsigned nMicroSeconds);
 
 	CTask *GetCurrentTask (void);
+	boolean IsValidTask(CTask* pTask);
 
 	void RegisterTaskSwitchHandler (TSchedulerTaskHandler *pHandler);
 	void RegisterTaskTerminationHandler (TSchedulerTaskHandler *pHandler);
@@ -49,6 +50,7 @@ public:
 	{
 		return s_pThis != 0 ? TRUE : FALSE;
 	}
+
 
 private:
 	void AddTask (CTask *pTask);

--- a/lib/sched/scheduler.cpp
+++ b/lib/sched/scheduler.cpp
@@ -121,6 +121,18 @@ CTask *CScheduler::GetCurrentTask (void)
 	return m_pCurrent;
 }
 
+boolean CScheduler::IsValidTask(CTask* pTask)
+{
+	unsigned i;
+	for (i = 0; i < m_nTasks; i++)
+	{
+		if (m_pTask[i] != 0 && m_pTask[i] == pTask)
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
 void CScheduler::RegisterTaskSwitchHandler (TSchedulerTaskHandler *pHandler)
 {
 	assert (m_pTaskSwitchHandler == 0);

--- a/lib/sched/task.cpp
+++ b/lib/sched/task.cpp
@@ -74,6 +74,12 @@ void CTask::Terminate (void)
 
 void CTask::WaitForTermination (void)
 {
+	// Before accessing any of our member variables
+	// make sure this task object hasn't been deleted by 
+	// checking it's still registered with the scheduler
+	if (!CScheduler::Get()->IsValidTask(this))
+		return;
+
 	m_Event.Wait ();
 }
 


### PR DESCRIPTION
This is a fix for a condition where `CTask::WaitForTermination` might be called on a task that's been deleted.  Because the scheduler deletes tasks when they're terminated its difficult to tell if a task pointer is still valid before waiting for its termination.

Consider this example:

```cpp
class CMyTask : public CTask
{
public:
	CMyTask() 
	{
		printk("Task constructor");
	}
	virtual ~CMyTask() 
	{
		printk("Task destructor     <--- Task ptr no longer valid");
	}
	virtual void Run() override
	{
		printk("Task running...");
		CScheduler::Get()->MsSleep(500);
		printk("Tash finished.");
	}
};


TShutdownMode CKernel::Run (void)
{
	m_Logger.Write (FromKernel, LogNotice, "Compile time: " __DATE__ " " __TIME__);

	printk("Creating Task");
	CTask* pTask = new CMyTask();

	printk("Main task sleeping for a bit...");
	CScheduler::Get()->MsSleep(1000);

	printk("Waiting Task        <--- Task ptr better still be valid");
	pTask->WaitForTermination();

	printk("Finished");
	return ShutdownReboot;
}
```

which produces the following output:

```
00:00:00.67 printk: Creating Task
00:00:00.67 printk: Task constructor
00:00:00.68 printk: Main task sleeping for a bit...
00:00:00.68 printk: Task running...
00:00:01.18 printk: Tash finished.
00:00:01.19 printk: Task destructor     <--- Task ptr no longer valid
00:00:01.68 printk: Waiting Task        <--- Task ptr better still be valid
00:00:01.69 printk: Finished
```

At the moment it works out pure luck that the memory where the task was hasn't been re-used.

The attached fix works by updating `WaitForTermination` to validate its `this` pointer by checking it's still registered in the scheduled tasks list.  Doing this before accessing any member variables should prevent crashes.

It also provides a public scheduler method `IsValidTask` that might be useful for other situations where the validity of a task pointer needs to be determined.