### PR TITLE
Fix for inability to separate raw key events from multiple keyboards

### DIFF
--- a/addon/vc4/interface/sample/hello_triangle2/kernel.cpp
+++ b/addon/vc4/interface/sample/hello_triangle2/kernel.cpp
@@ -21,7 +21,7 @@
 
 extern "C" int _main (void);
 extern "C" void mouse_callback (unsigned nButtons, int nDisplacementX, int nDisplacementY,
-				int nWheelMove);
+				int nWheelMove, void* arg);
 
 static const char FromKernel[] = "kernel";
 

--- a/addon/vc4/interface/sample/hello_triangle2/triangle2.c
+++ b/addon/vc4/interface/sample/hello_triangle2/triangle2.c
@@ -456,7 +456,7 @@ static void draw_triangles(CUBE_STATE_T *state, GLfloat cx, GLfloat cy, GLfloat 
 static DEFINE_SPINLOCK (mouse_lock);
 static int mouse_buttons = 0, mouse_dx = 0, mouse_dy = 0;
 
-void mouse_callback (unsigned buttons, int dx, int dy, int wheelmove)
+void mouse_callback (unsigned buttons, int dx, int dy, int wheelmove, void* arg)
 {
    spin_lock (&mouse_lock);
 

--- a/include/circle/input/mouse.h
+++ b/include/circle/input/mouse.h
@@ -28,7 +28,7 @@
 #define MOUSE_DISPLACEMENT_MIN	-127
 #define MOUSE_DISPLACEMENT_MAX	127
 
-typedef void TMouseStatusHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove);
+typedef void TMouseStatusHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove, void* arg);
 
 class CMouseDevice : public CDevice	/// Generic mouse interface device ("mouse1")
 {
@@ -64,7 +64,7 @@ public:
 
 	/// \brief Register mouse status handler in raw mode
 	/// \param pStatusHandler Pointer to the mouse status handler
-	void RegisterStatusHandler (TMouseStatusHandler *pStatusHandler);
+	void RegisterStatusHandler (TMouseStatusHandler *pStatusHandler, void* arg = 0);
 
 	/// \return Number of supported mouse buttons
 	unsigned GetButtonCount (void) const;
@@ -80,6 +80,7 @@ private:
 	CMouseBehaviour m_Behaviour;
 
 	TMouseStatusHandler *m_pStatusHandler;
+	void* m_pStatusHandlerArg;
 
 	unsigned m_nDeviceNumber;
 	static CNumberPool s_DeviceNumberPool;

--- a/include/circle/usb/usbkeyboard.h
+++ b/include/circle/usb/usbkeyboard.h
@@ -29,8 +29,11 @@
 #define USBKEYB_REPORT_SIZE	8
 
 // The raw handler is called when the keyboard sends a status report (on status change and/or continously).
-typedef void TKeyStatusHandlerRaw (unsigned char	ucModifiers,	// see usbhid.h
-				   const unsigned char	RawKeys[6]);	// key code or 0 in each byte
+typedef void TKeyStatusHandlerRaw (
+					unsigned char	ucModifiers,	// see usbhid.h
+				   	const unsigned char	RawKeys[6],	// key code or 0 in each byte
+					void* arg
+					);	
 
 class CUSBKeyboardDevice : public CUSBHIDDevice
 {
@@ -52,7 +55,7 @@ public:
 
 	// raw mode (if bMixedMode is FALSE, the cooked handlers are ignored)
 	void RegisterKeyStatusHandlerRaw (TKeyStatusHandlerRaw *pKeyStatusHandlerRaw,
-					  boolean bMixedMode = FALSE);
+					  boolean bMixedMode = FALSE, void* arg = nullptr);
 
 	// works in cooked and raw mode
 	boolean SetLEDs (u8 ucStatus);		// must not be called in interrupt context
@@ -67,6 +70,7 @@ private:
 
 	TKeyStatusHandlerRaw *m_pKeyStatusHandlerRaw;
 	boolean m_bMixedMode;
+	void* m_pRawHandlerArg;
 
 	u8 m_LastReport[USBKEYB_REPORT_SIZE];
 

--- a/include/circle/usb/usbkeyboard.h
+++ b/include/circle/usb/usbkeyboard.h
@@ -55,7 +55,7 @@ public:
 
 	// raw mode (if bMixedMode is FALSE, the cooked handlers are ignored)
 	void RegisterKeyStatusHandlerRaw (TKeyStatusHandlerRaw *pKeyStatusHandlerRaw,
-					  boolean bMixedMode = FALSE, void* arg = nullptr);
+					  boolean bMixedMode = FALSE, void* arg = 0);
 
 	// works in cooked and raw mode
 	boolean SetLEDs (u8 ucStatus);		// must not be called in interrupt context

--- a/lib/input/mouse.cpp
+++ b/lib/input/mouse.cpp
@@ -72,10 +72,11 @@ void CMouseDevice::UpdateCursor (void)
 	}
 }
 
-void CMouseDevice::RegisterStatusHandler (TMouseStatusHandler *pStatusHandler)
+void CMouseDevice::RegisterStatusHandler (TMouseStatusHandler *pStatusHandler, void* arg)
 {
 	assert (m_pStatusHandler == 0);
 	m_pStatusHandler = pStatusHandler;
+	m_pStatusHandlerArg = arg;
 	assert (m_pStatusHandler != 0);
 }
 
@@ -85,7 +86,7 @@ void CMouseDevice::ReportHandler (unsigned nButtons, int nDisplacementX, int nDi
 
 	if (m_pStatusHandler != 0)
 	{
-		(*m_pStatusHandler) (nButtons, nDisplacementX, nDisplacementY, nWheelMove);
+		(*m_pStatusHandler) (nButtons, nDisplacementX, nDisplacementY, nWheelMove, m_pStatusHandlerArg);
 	}
 }
 

--- a/lib/usb/usbkeyboard.cpp
+++ b/lib/usb/usbkeyboard.cpp
@@ -129,10 +129,11 @@ u8 CUSBKeyboardDevice::GetLEDStatus (void) const
 }
 
 void CUSBKeyboardDevice::RegisterKeyStatusHandlerRaw (TKeyStatusHandlerRaw *pKeyStatusHandlerRaw,
-						      boolean bMixedMode)
+						      boolean bMixedMode, void* arg)
 {
 	assert (pKeyStatusHandlerRaw != 0);
 	m_pKeyStatusHandlerRaw = pKeyStatusHandlerRaw;
+	m_pRawHandlerArg = arg;
 
 	m_bMixedMode = bMixedMode;
 }
@@ -162,7 +163,7 @@ void CUSBKeyboardDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)
 
 	if (m_pKeyStatusHandlerRaw != 0)
 	{
-		(*m_pKeyStatusHandlerRaw) (pReport[0], pReport+2);
+		(*m_pKeyStatusHandlerRaw) (pReport[0], pReport+2, m_pRawHandlerArg);
 
 		if (!m_bMixedMode)
 		{

--- a/sample/08-usbkeyboard/kernel.cpp
+++ b/sample/08-usbkeyboard/kernel.cpp
@@ -143,7 +143,7 @@ void CKernel::ShutdownHandler (void)
 	s_pThis->m_ShutdownMode = ShutdownReboot;
 }
 
-void CKernel::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6])
+void CKernel::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6], void* arg)
 {
 	assert (s_pThis != 0);
 

--- a/sample/08-usbkeyboard/kernel.h
+++ b/sample/08-usbkeyboard/kernel.h
@@ -55,7 +55,7 @@ private:
 	static void KeyPressedHandler (const char *pString);
 	static void ShutdownHandler (void);
 
-	static void KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6]);
+	static void KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6], void* arg);
 
 	static void KeyboardRemovedHandler (CDevice *pDevice, void *pContext);
 

--- a/sample/29-miniorgan/miniorgan.cpp
+++ b/sample/29-miniorgan/miniorgan.cpp
@@ -297,7 +297,7 @@ void CMiniOrgan::MIDIPacketHandler (unsigned nCable, u8 *pPacket, unsigned nLeng
 	}
 }
 
-void CMiniOrgan::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6])
+void CMiniOrgan::KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6], void* arg)
 {
 	assert (s_pThis != 0);
 

--- a/sample/29-miniorgan/miniorgan.h
+++ b/sample/29-miniorgan/miniorgan.h
@@ -59,7 +59,7 @@ public:
 private:
 	static void MIDIPacketHandler (unsigned nCable, u8 *pPacket, unsigned nLength);
 
-	static void KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6]);
+	static void KeyStatusHandlerRaw (unsigned char ucModifiers, const unsigned char RawKeys[6], void* arg);
 
 	static void USBDeviceRemovedHandler (CDevice *pDevice, void *pContext);
 


### PR DESCRIPTION
This PR adds a user supplied callback argument to the `CUSBKeyboardDevice::RegisterKeyStatusHandlerRaw`.

Since key transitions are determined by comparing one set of RawKeys with a previous set it's important that the set being compared to is from the same device. Without this fix, a client can't separate out the RawKeys from multiple keyboards making it impossible to determine key state transitions as the RawKeys for each device will be interleaved.

By adding a user supplied callback argument the client can match the received callback events to a particular device.

The same thing applies for raw mouse handler button states.

Unfortunately this is a breaking API change but solves an otherwise impossible to rectify issue.  I've updated all the samples that use these methods.