### PR TITLE
Improvements to Task Synchronization primitives

### DIFF
--- a/doc/classes.txt
+++ b/doc/classes.txt
@@ -146,6 +146,7 @@ Scheduler library
 * CTask: Overload this class, define the Run() method to implement your own task and call new on it to start it.
 * CScheduler: Cooperative non-preemtive scheduler which controls which task runs at a time.
 * CSynchronizationEvent: Provides a method to synchronize the execution of a task with an event.
+* CSynchronizationMutex: Provides a method to provide mutual exclusion (critical sections) across tasks.
 
 Net library
 

--- a/include/circle/sched/scheduler.h
+++ b/include/circle/sched/scheduler.h
@@ -59,7 +59,7 @@ private:
 	void AddTask (CTask *pTask);
 	friend class CTask;
 
-	void BlockTask (CTask **ppTask);
+	bool BlockTask (CTask **ppTask, unsigned nMicroSeconds);
 	void WakeTask (CTask **ppTask);		// can be called from interrupt context
 	friend class CSynchronizationEvent;
 

--- a/include/circle/sched/scheduler.h
+++ b/include/circle/sched/scheduler.h
@@ -59,8 +59,8 @@ private:
 	void AddTask (CTask *pTask);
 	friend class CTask;
 
-	bool BlockTask (CTask **ppTask, unsigned nMicroSeconds);
-	void WakeTask (CTask **ppTask);		// can be called from interrupt context
+	bool BlockTask (CTask **ppWaitListHead, unsigned nMicroSeconds);
+	void WakeTasks (CTask **ppWaitListHead);		// can be called from interrupt context
 	friend class CSynchronizationEvent;
 
 	void RemoveTask (CTask *pTask);

--- a/include/circle/sched/synchronizationevent.h
+++ b/include/circle/sched/synchronizationevent.h
@@ -36,6 +36,7 @@ public:
 	void Set (void);	// can be called from interrupt context
 
 	void Wait (void);
+	bool WaitWithTimeout (unsigned nMicroSeconds);
 
 private:
 	volatile boolean m_bState;

--- a/include/circle/sched/synchronizationmutex.h
+++ b/include/circle/sched/synchronizationmutex.h
@@ -1,5 +1,5 @@
 //
-// synchronizationevent.h
+// synchronizationmutex.h
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
 // Copyright (C) 2015-2019  R. Stange <rsta2@o2online.de>
@@ -17,32 +17,27 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
-#ifndef _circle_sched_synchronizationevent_h
-#define _circle_sched_synchronizationevent_h
+#ifndef _circle_sched_synchronizationmutex_h
+#define _circle_sched_synchronizationmutex_h
 
 #include <circle/types.h>
+#include <circle/sched/synchronizationevent.h>
 
 class CTask;
 
-class CSynchronizationEvent
+class CSynchronizationMutex
 {
 public:
-	CSynchronizationEvent (boolean bState = FALSE);
-	~CSynchronizationEvent (void);
+	CSynchronizationMutex (void);
+    ~CSynchronizationMutex (void);
 
-	boolean GetState (void);
-
-	void Clear (void);
-	void Set (void);	// can be called from interrupt context
-	void Pulse (void);	// wakes all waiting tasks without actually setting the event
-
-	void Wait (void);
-	bool WaitWithTimeout (unsigned nMicroSeconds);
+	void Acquire (void);
+	void Release (void);
 
 private:
-	volatile boolean m_bState;
-	CTask		*m_pWaitListHead;	// Linked list of waiting tasks
+	CTask* m_pOwningTask;
+	int m_iReentrancyCount;
+	CSynchronizationEvent m_event;
 };
-
 
 #endif

--- a/include/circle/sched/task.h
+++ b/include/circle/sched/task.h
@@ -82,7 +82,7 @@ private:
 	u8		   *m_pStack;
 	void		   *m_pUserData[TASK_USER_DATA_SLOTS];
 	CSynchronizationEvent m_Event;
-
+	CTask*			m_pWaitListNext;	// next in list of tasks waiting on an event
 };
 
 #endif

--- a/include/circle/sched/task.h
+++ b/include/circle/sched/task.h
@@ -32,6 +32,7 @@ enum TTaskState
 	TaskStateSleeping,
 	TaskStateTerminated,
 	TaskStateNew,
+	TaskStateBlockedWithTimeout,
 	TaskStateUnknown
 };
 

--- a/lib/sched/Makefile
+++ b/lib/sched/Makefile
@@ -20,7 +20,7 @@
 
 CIRCLEHOME = ../..
 
-OBJS	= task.o scheduler.o taskswitch.o synchronizationevent.o
+OBJS	= task.o scheduler.o taskswitch.o synchronizationevent.o synchronizationmutex.o
 
 libsched.a: $(OBJS)
 	@echo "  AR    $@"

--- a/lib/sched/synchronizationevent.cpp
+++ b/lib/sched/synchronizationevent.cpp
@@ -71,8 +71,29 @@ void CSynchronizationEvent::Wait (void)
 	if (!m_bState)
 	{
 		assert (m_pWaitTask == 0);
-		CScheduler::Get ()->BlockTask (&m_pWaitTask);
+		CScheduler::Get ()->BlockTask (&m_pWaitTask, 0);
 
 		assert (m_bState);
 	}
 }
+
+// Wait for this event to be signalled, or a time period to elapse.
+// To determine what caused the method to return:
+//    - returns true if timed out
+//    - use GetState() to see if event has been signalled
+// Note, it's possible to have timed out and for the event to be set
+bool CSynchronizationEvent::WaitWithTimeout (unsigned nMicroSeconds)
+{
+	if (m_bState)
+	{
+		return nMicroSeconds == 0;
+	}
+	else
+	{
+		assert(m_pWaitTask == 0);
+		bool retv = CScheduler::Get ()->BlockTask (&m_pWaitTask, nMicroSeconds);
+		m_pWaitTask = 0;
+		return retv;
+	}
+}
+

--- a/lib/sched/synchronizationmutex.cpp
+++ b/lib/sched/synchronizationmutex.cpp
@@ -1,0 +1,69 @@
+//
+// synchronizationmutex.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2015-2019  R. Stange <rsta2@o2online.de>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <circle/sched/synchronizationmutex.h>
+#include <circle/sched/scheduler.h>
+#include <circle/sched/task.h>
+#include <circle/synchronize.h>
+#include <circle/sysconfig.h>
+#include <assert.h>
+
+CSynchronizationMutex::CSynchronizationMutex (void)
+:   m_pOwningTask (0),
+    m_iReentrancyCount (0)
+{
+}
+
+CSynchronizationMutex::~CSynchronizationMutex (void)
+{
+    assert(m_pOwningTask == 0);
+}
+
+void CSynchronizationMutex::Acquire (void)
+{
+    CTask* pTask = CScheduler::Get()->GetCurrentTask();
+
+    while (true)
+    {
+        if (m_pOwningTask == nullptr)
+        {
+            m_pOwningTask = pTask;
+            m_iReentrancyCount = 1;
+            return;
+        }
+        else if (m_pOwningTask == pTask)
+        {
+            m_iReentrancyCount++;
+            return;
+        }
+        m_event.Wait();
+    }
+}
+
+void CSynchronizationMutex::Release (void)
+{
+    assert(m_pOwningTask == CScheduler::Get()->GetCurrentTask());
+    m_iReentrancyCount--;
+    if (m_iReentrancyCount == 0)
+    {
+        m_pOwningTask = 0;
+        m_event.Pulse();
+        CScheduler::Get()->Yield();
+    }
+}

--- a/lib/sched/task.cpp
+++ b/lib/sched/task.cpp
@@ -25,7 +25,8 @@
 CTask::CTask (unsigned nStackSize, bool createSuspended)
 :	m_State (createSuspended ? TaskStateNew : TaskStateReady),
 	m_nStackSize (nStackSize),
-	m_pStack (0)
+	m_pStack (0),
+	m_pWaitListNext (0)
 {
 	for (unsigned i = 0; i < TASK_USER_DATA_SLOTS; i++)
 	{

--- a/sample/41-syncrhonization/Makefile
+++ b/sample/41-syncrhonization/Makefile
@@ -1,0 +1,14 @@
+#
+# Makefile
+#
+
+CIRCLEHOME = ../..
+
+OBJS	= main.o kernel.o
+
+LIBS	= $(CIRCLEHOME)/lib/sched/libsched.a \
+	  $(CIRCLEHOME)/lib/libcircle.a
+
+include ../Rules.mk
+
+-include $(DEPS)

--- a/sample/41-syncrhonization/README
+++ b/sample/41-syncrhonization/README
@@ -1,0 +1,9 @@
+README
+
+This sample demonstrates/tests the synchronization primitives that form part of the optional cooperative non-preemtive scheduler which is available in Circle. The scheduler allows to have several independent threads of execution in a Circle application which may ease the programming model.
+
+The first example demonstrates CEvent::WaitWithTimeout() by waiting on an event in a loop with a 1 second timeout while a 5 second kernel timer is used to signal it.
+
+The second example demonstrates multiple tasks waiting on a single event in order to exercise/test this new functionality.  Some of the tasks wait with a timeout to test the removal of a single task from an event's task wait list.
+
+The third example demonstrates CSynchronizationMutex by having multiple tasks simulate an atomic increment of a counter.  Each task acquires the mutex and splits the increment operation across a sleep during which other tasks can run, but those waiting on the mutex will be locked out.  At the end the counter value is checked to ensure none of the atomic operations were violated.

--- a/sample/41-syncrhonization/kernel.cpp
+++ b/sample/41-syncrhonization/kernel.cpp
@@ -1,0 +1,204 @@
+//
+// kernel.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2015-2018  R. Stange <rsta2@o2online.de>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "kernel.h"
+#include <circle/string.h>
+#include <assert.h>
+
+static const char FromKernel[] = "kernel";
+
+CKernel::CKernel (void)
+:	m_Screen (m_Options.GetWidth (), m_Options.GetHeight ()),
+	m_Timer (&m_Interrupt),
+	m_Logger (m_Options.GetLogLevel (), &m_Timer)
+{
+	m_ActLED.Blink (5);	// show we are alive
+}
+
+CKernel::~CKernel (void)
+{
+}
+
+boolean CKernel::Initialize (void)
+{
+	boolean bOK = TRUE;
+
+	if (bOK)
+	{
+		bOK = m_Screen.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_Serial.Initialize (115200);
+	}
+
+	if (bOK)
+	{
+		CDevice *pTarget = m_DeviceNameService.GetDevice (m_Options.GetLogDevice (), FALSE);
+		if (pTarget == 0)
+		{
+			pTarget = &m_Screen;
+		}
+
+		bOK = m_Logger.Initialize (pTarget);
+	}
+
+	if (bOK)
+	{
+		bOK = m_Interrupt.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_Timer.Initialize ();
+	}
+
+	return bOK;
+}
+
+class CWorkerTask : public CTask
+{
+public:
+	CWorkerTask(int id, int timeout, CSynchronizationEvent* pEvent)
+	{
+		m_id = id;
+		m_timeout = timeout;
+		m_pEvent = pEvent;
+	}
+
+	virtual void Run() override
+	{
+		CLogger::Get()->Write (FromKernel, LogNotice, "Worker %i waiting for event with timeout %ims...", m_id, m_timeout);
+		while (!m_pEvent->GetState())
+		{
+			if (m_pEvent->WaitWithTimeout(m_timeout * 1000))
+				CLogger::Get()->Write (FromKernel, LogNotice, "Worker %i timed out", m_id);
+		}
+		CLogger::Get()->Write (FromKernel, LogNotice, "Worker %i signalled!", m_id);
+	}
+
+	int m_id;
+	int m_timeout;
+	CSynchronizationEvent* m_pEvent;
+};
+
+class CCounterTask : public CTask
+{
+public:
+	CCounterTask(int id, int timeout, int* piCounter, CSynchronizationMutex* pMutex)
+	{
+		m_id = id;
+		m_timeout = timeout;
+		m_piCounter = piCounter;
+		m_pMutex = pMutex;
+	}
+
+	virtual void Run() override
+	{
+		for (int i=0; i<10; i++)
+		{
+			// Simulates an atomic operation with intervening sleep
+
+			// Get mutex
+			CLogger::Get()->Write (FromKernel, LogNotice, "Counter task %i iter %i", m_id, i);
+			m_pMutex->Acquire();
+			CLogger::Get()->Write (FromKernel, LogNotice, "Counter task %i mutex acquired", m_id);
+
+			// Part 1 of atomic op
+			int value = *m_piCounter;
+
+			// No one ele should get in while we sleep
+			CScheduler::Get()->MsSleep(m_timeout);
+
+			// Part 2 of atomic op
+			*m_piCounter = value + 1;
+
+			// Give someone else a go...
+			CLogger::Get()->Write (FromKernel, LogNotice, "Counter task %i releasing mutex", m_id);
+			m_pMutex->Release();
+		}
+	
+		CLogger::Get()->Write (FromKernel, LogNotice, "Counter %i finished.", m_id);
+	}
+	
+
+	int m_id;
+	int m_timeout;
+	int* m_piCounter;
+	CSynchronizationMutex* m_pMutex;
+};
+
+TShutdownMode CKernel::Run (void)
+{
+	m_Logger.Write (FromKernel, LogNotice, "Compile time: " __DATE__ " " __TIME__);
+
+	// Example 1 - Wait with Timeout
+	m_Logger.Write (FromKernel, LogNotice, "\n\n### Example 1 - Wait with Timeout ###");
+	m_Timer.StartKernelTimer (5 * HZ, TimerHandler, this);	// 5 seconds
+	m_Logger.Write (FromKernel, LogNotice, "Event will trigger in 5 seconds");
+	m_Logger.Write (FromKernel, LogNotice, "Waiting for event with 1 second timeout...");
+	while (!m_Event.GetState())
+	{
+		if (m_Event.WaitWithTimeout(1000000))		// 1 second
+		{
+			m_Logger.Write (FromKernel, LogNotice, "  time out!");
+		}
+	}
+	m_Logger.Write (FromKernel, LogNotice, "Event signalled");
+	m_Event.Clear();
+
+	// Example 2 - Multi-task Wait (some with timeouts)
+	m_Logger.Write (FromKernel, LogNotice, "\n\n### Example 2 - Multi-task Wait ###");
+	new CWorkerTask(1, 0, &m_Event);
+	new CWorkerTask(2, 300, &m_Event);
+	new CWorkerTask(3, 600, &m_Event);
+	new CWorkerTask(4, 900, &m_Event);
+	new CWorkerTask(0, 0, &m_Event);
+	m_Logger.Write (FromKernel, LogNotice, "Event will trigger in 5 seconds...");
+	CScheduler::Get()->MsSleep(5000);
+	m_Logger.Write (FromKernel, LogNotice, "Triggering event...");
+	m_Event.Set();
+	m_Logger.Write (FromKernel, LogNotice, "Event triggered");
+	CScheduler::Get()->Yield();
+
+	// Example 3 - Mutexes
+	m_Logger.Write (FromKernel, LogNotice, "\n\n### Example 3 - Mutexes ###");
+	int counter = 0;
+	new CCounterTask(1, 10, &counter, &m_Mutex);
+	new CCounterTask(2, 20, &counter, &m_Mutex);
+	new CCounterTask(3, 30, &counter, &m_Mutex);
+	new CCounterTask(4, 40, &counter, &m_Mutex);
+	new CCounterTask(5, 50, &counter, &m_Mutex);
+	CScheduler::Get()->MsSleep(3000);		// Approx how long above tasks will take
+	m_Logger.Write (FromKernel, LogNotice, "Final counter: %i (should be 50)", counter);
+	assert(counter == 50);
+
+
+	m_Logger.Write (FromKernel, LogNotice, "Finished!");
+	CScheduler::Get()->MsSleep(1000);
+	return ShutdownReboot;
+}
+
+void CKernel::TimerHandler (TKernelTimerHandle hTimer, void *pParam, void *pContext)
+{
+	CKernel *pThis = (CKernel *) pParam;
+	assert (pThis != 0);
+	pThis->m_Event.Set ();
+}

--- a/sample/41-syncrhonization/kernel.h
+++ b/sample/41-syncrhonization/kernel.h
@@ -1,0 +1,76 @@
+//
+// kernel.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2015-2018  R. Stange <rsta2@o2online.de>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _kernel_h
+#define _kernel_h
+
+#include <circle/memory.h>
+#include <circle/actled.h>
+#include <circle/koptions.h>
+#include <circle/devicenameservice.h>
+#include <circle/screen.h>
+#include <circle/serial.h>
+#include <circle/exceptionhandler.h>
+#include <circle/interrupt.h>
+#include <circle/timer.h>
+#include <circle/logger.h>
+#include <circle/sched/scheduler.h>
+#include <circle/sched/synchronizationevent.h>
+#include <circle/sched/synchronizationmutex.h>
+#include <circle/types.h>
+
+enum TShutdownMode
+{
+	ShutdownNone,
+	ShutdownHalt,
+	ShutdownReboot
+};
+
+class CKernel
+{
+public:
+	CKernel (void);
+	~CKernel (void);
+
+	boolean Initialize (void);
+
+	TShutdownMode Run (void);
+	
+private:
+	static void TimerHandler (TKernelTimerHandle hTimer, void *pParam, void *pContext);
+
+private:
+	// do not change this order
+	CMemorySystem		m_Memory;
+	CActLED			m_ActLED;
+	CKernelOptions		m_Options;
+	CDeviceNameService	m_DeviceNameService;
+	CScreenDevice		m_Screen;
+	CSerialDevice		m_Serial;
+	CExceptionHandler	m_ExceptionHandler;
+	CInterruptSystem	m_Interrupt;
+	CTimer			m_Timer;
+	CLogger			m_Logger;
+
+	CScheduler		m_Scheduler;
+	CSynchronizationEvent	m_Event;
+	CSynchronizationMutex	m_Mutex;
+};
+
+#endif

--- a/sample/41-syncrhonization/main.cpp
+++ b/sample/41-syncrhonization/main.cpp
@@ -1,8 +1,8 @@
 //
-// synchronizationevent.h
+// main.c
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2015-2019  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2014  R. Stange <rsta2@o2online.de>
 // 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,32 +17,31 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
-#ifndef _circle_sched_synchronizationevent_h
-#define _circle_sched_synchronizationevent_h
+#include "kernel.h"
+#include <circle/startup.h>
 
-#include <circle/types.h>
-
-class CTask;
-
-class CSynchronizationEvent
+int main (void)
 {
-public:
-	CSynchronizationEvent (boolean bState = FALSE);
-	~CSynchronizationEvent (void);
+	// cannot return here because some destructors used in CKernel are not implemented
 
-	boolean GetState (void);
+	CKernel Kernel;
+	if (!Kernel.Initialize ())
+	{
+		halt ();
+		return EXIT_HALT;
+	}
+	
+	TShutdownMode ShutdownMode = Kernel.Run ();
 
-	void Clear (void);
-	void Set (void);	// can be called from interrupt context
-	void Pulse (void);	// wakes all waiting tasks without actually setting the event
+	switch (ShutdownMode)
+	{
+	case ShutdownReboot:
+		reboot ();
+		return EXIT_REBOOT;
 
-	void Wait (void);
-	bool WaitWithTimeout (unsigned nMicroSeconds);
-
-private:
-	volatile boolean m_bState;
-	CTask		*m_pWaitListHead;	// Linked list of waiting tasks
-};
-
-
-#endif
+	case ShutdownHalt:
+	default:
+		halt ();
+		return EXIT_HALT;
+	}
+}


### PR DESCRIPTION
This PR adds:

* A new method `CSynchonizationEvent::WaitWithTimeout()` that yields the current task until either the event is signaled or a timeout period expires.
* Support for multiple tasks waiting on a single `CSynchronizationEvent`
* A new class `CSynchronizationMutex` that provides mutual exclusion capability across yielding tasks

It also includes a new sample program `41-synchronization` that demonstrates/exercises all of the above and I've added CSynchronizationMutex to the doc/classes.txt file.

This is a non-breaking API change.

