### PR TITLE
New Flash Tool with Ack and Fast Flash

### DIFF
--- a/Rules.mk
+++ b/Rules.mk
@@ -190,11 +190,49 @@ $(TARGET).hex: $(TARGET).img
 	@echo "  COPY  $(TARGET).hex"
 	@$(PREFIX)objcopy $(TARGET).elf -O ihex $(TARGET).hex
 
+# Command line to run node and python.  
+# Including the '.exe' forces WSL to run the Windows host version
+# of these commands.  If putty and node are available on the windows 
+# machine we can get around WSL's lack of serial port support
+ifeq ($(strip $(WSL_DISTRO_NAME)),)
+NODE=node 
+PUTTY=putty
+PUTTYSERIALPORT=$(SERIALPORT)
+else
+NODE=node.exe
+PUTTY=putty.exe
+PUTTYSERIALPORT=$(subst /dev/ttyS,COM,$(SERIALPORT))		# Remap to windows name
+endif
+
+ifeq ($(strip $(USEFLASHY)),)
+
+# Flash with python
 flash: $(TARGET).hex
 ifneq ($(strip $(REBOOTMAGIC)),)
 	python3 $(CIRCLEHOME)/tools/reboottool.py $(REBOOTMAGIC) $(SERIALPORT) $(USERBAUD)
 endif
 	python3 $(CIRCLEHOME)/tools/flasher.py $(TARGET).hex $(SERIALPORT) $(FLASHBAUD)
 
+else
+
+# Flash with flashy
+flash: $(TARGET).hex
+	$(NODE) $(CIRCLEHOME)/tools/flashy/flashy.js \
+		$(SERIALPORT) \
+		--flashBaud:$(FLASHBAUD) \
+		--userBaud:$(USERBAUD) \
+		--reboot:$(REBOOTMAGIC) \
+		$(TARGET).hex
+
+endif
+
+# Monitor in putty
 monitor:
-	putty -serial $(SERIALPORT) -sercfg $(USERBAUD)
+	$(PUTTY) -serial $(PUTTYSERIALPORT) -sercfg $(USERBAUD)
+
+# Monitor in terminal (Linux only)
+cat:
+	stty -F $(SERIALPORT) $(USERBAUD) cs8 -cstopb -parenb -icrnl
+	cat $(SERIALPORT)
+
+

--- a/doc/bootloader.txt
+++ b/doc/bootloader.txt
@@ -54,3 +54,67 @@ right communication parameters.
 
 8. To start another development cycle, power off and on the Raspberry Pi, and
 after rebuilding do again "make flash".
+
+
+Using the New New Flash Tool "Flashy"
+-------------------------------------
+
+The above procedure describes flashing the device using the traditional python3
+based flash tool.  Circle also includes a new flash tool "flashy" that provides some
+improved features.  This tool is written in JavaScript and requires NodeJS to be installed.
+
+* Unlike the old tool that just blasts at the serial port and hopes the bootloader
+  is listening, the new tool pings the bootloader and waits for a response to ensures it's 
+  ready for the transfer before sending it.
+
+* It can automatically send a magic reboot string and wait for the device to become ready 
+  before starting the transfer.  (Faster since pessimistic delay times aren't required)
+
+* Once flashed, it can automatically switch into monitor mode (switching baud rates if 
+  necessary) to view the output of the flashed program.
+
+* It can reset the bootloader to recover from a previously cancelled transfer
+
+
+
+To use the new flash tool:
+
+1. Make sure you have NodeJS installed
+
+2. Go to the `tools/flashy` sub-folder and run `npm install` to install the required 
+   serial port module.
+
+3. If you're currently using an old version of the bootloader, rebuild the latest
+   version and copy it to the SD card. (Optional, works better with this)
+
+4. In your Config.mk set the variable `USEFLASHY`, along with the other settings 
+   described above:
+
+        USEFLASHY = 1
+        SERIALPORT = /dev/ttyUSB0
+        FLASHBAUD = 115200
+        USERBAUD = 115200
+        REBOOTMAGIC = <magicstring>
+
+5. Flash the device as per before:
+
+        make flash
+
+Here's what will happen:
+
+* If the device is running a program that supports reboot magic, it will automatically
+  reboot and the flash transfer will start when the bootloader is ready.
+
+* If the device is off, or running a program that doesn't support reboot magic, just 
+  power on or reset the device and the transfer will start when the bootloader is ready.
+
+* If the device is on, but the bootloader hasn't loaded anything yet, or a previous
+  flash operation was cancelled, the bootloader will be automatically restarted and a new 
+  transfer initiated.  
+  
+This last point requires the new bootloader. If you're running the old bootloader you'll 
+need to manually reset the device or do the transfer without acknowledgement (ie: use the
+`--noack` switch which will transfer the file and just hope  the bootloader is listening).
+
+For details on using this under WSL, see the [Windows build instructions](windows-build.txt)
+

--- a/doc/windows-build.txt
+++ b/doc/windows-build.txt
@@ -90,3 +90,32 @@ for instructions on setting it up:
     https://aka.ms/vscode-remote/download/extension
 
 For build instructions, please refer to the circle documentation for building under Linux.
+
+
+Using WSL 2
+-----------
+
+The main disadvantage of using WSL 1 is much slower build times (twice as long).  Unfortunately
+WSL 2 lacks serial port support but if you only need to flash the device and monitor its output 
+there's a fairly simple work around - use Windows tools and the new [bootloader flash tool](bootloader.txt).
+
+(This approach doesn't work with the Python tool - for some reason Python fails to start from
+inside the WSL machine).
+
+Under WSL, a Windows program can be launched from within the WSL machine and its files accessed
+via a UNC path name.  This functionality can be leveraged so that all build operations happen 
+in the WSL machine, but flashing and serial monitoring done with Windows programs.  Circle's 
+Rules.mk file is already configured for this but it requires a few steps of preparation.
+
+1. Install NodeJS and Putty on the Windows machine and make sure both are in the path.
+
+2. Install the node serial port module from Windows - not from the WSL machine.  eg:
+
+	WindowsCmdPrompt> pushd \\wsl$\yourmachine\home\yourname\Projects\circle\tools\flashy
+	WindowsCmdPrompt> rmdir /S node_modules
+	WindowsCmdPrompt> npm install
+
+3. Configure the serial port in Config.mk using the Windows port name instead of the Linux
+   port name (eg: `COM3` not `/dev/ttyS3`)
+
+

--- a/tools/flashy/.gitignore
+++ b/tools/flashy/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+launch.json
+package-lock.json

--- a/tools/flashy/flashy.js
+++ b/tools/flashy/flashy.js
@@ -1,0 +1,565 @@
+let fs = require('fs');
+let os = require('os');
+let util = require('util');
+let stdout = process.stdout;
+
+// Command line options
+let hexFile = null;
+let serialPortName = null;
+let serialPortOptions = {
+    dataBits: 8,
+    stopBits: 1,
+    parity: 'none',
+};
+let flashBaud = 115200;
+let userBaud = 115200;
+let waitForAck = true;
+let goSwitch = false;
+let nogoSwitch = false;
+let rebootMagic = null;
+let rebootDelay = null;
+let monitor = false;
+let noFast = false;
+
+// The currently open serial port
+let port;
+
+// The serial port module (delayed load)
+let SerialPort;
+let fastMode = false;
+
+// Open the serial port at specified baud rate, closing and reopening
+// if currently open at a different rate
+async function openSerialPortAsync(baudRate)
+{
+    // Already open?
+    if (port != null)
+    {
+        // Correct baud rate already?
+        if (serialPortOptions.baudRate == baudRate)
+            return;
+
+        // Close the port
+        await closeSerialPortAsync();
+    }
+    
+    // Load the serial port module and display handy message if can't
+    if (!SerialPort)
+    {
+        try
+        {
+            SerialPort = require('serialport');
+        }
+        catch (err)
+        {
+            console.log(`\nCan't find module 'serialport'.`);
+            console.log(`Please run 'npm install' in the flashy script folder:\n`);
+            console.log(`   ` + __dirname + `$ npm install`);
+            process.exit(7);
+        }
+    }
+    
+    // Remap WSL serial port names to Windows equivalent if appropriate
+    if (os.platform() == 'win32' && serialPortName.startsWith(`/dev/ttyS`))
+    {
+        let remapped = `COM` + serialPortName.substr(9);
+        stdout.write(`Using '${remapped}' instead of WSL port '${serialPortName}'.\n`)
+        serialPortName = remapped;
+    }
+
+    // Configure options
+    serialPortOptions.baudRate = baudRate;
+
+    // Open it
+    stdout.write(`Opening ${serialPortName} at ${baudRate}...`)
+    port = new SerialPort(serialPortName, serialPortOptions, function(err) {
+        if (err)
+        {
+            fail(`Failed to open serial port: ${err.message}`);
+        }
+    });
+    stdout.write(`ok\n`);
+}
+
+// Close the serial port (if it's open)
+async function closeSerialPortAsync()
+{
+    if (port)
+    {
+        stdout.write(`Closing serial port...`)
+
+        // Close the port
+        await new Promise((resolve, reject) => {
+            port.close(function(err) { 
+                if (err)
+                    reject(err);
+                else
+                {
+                    stdout.write(`ok\n`);
+                    resolve();
+                }
+            });
+        });
+    }
+}
+
+// Async wrapper for write operations so we don't have to deal with callbacks
+async function writeSerialPortAsync(data) 
+{
+    return new Promise((resolve,reject) => 
+    {
+        port.write(data, function(err) 
+        {
+            if (err)
+                reject(err);
+            else
+                resolve();
+        });
+    });
+};
+
+
+// The fast flash write works by switching to binary mode for seqeuences
+// of hex digit pairs that appear immediately after a ':' (99.9% typical case)
+// The send format is to instead an '=' to indicate binary line, followed
+// by a length byte, followed by the binary data
+// 
+// eg: ":0011223344" becomes '=' 0x05 0x00 0x11 0x22 0x33 0x44
+
+let fast_write_buffer = Buffer.alloc(4096);
+let fast_write_buffer_used = 0;
+let fast_unsent_nibble = -1;
+let fast_unsent_byte_count = 0;
+
+// Flush the fast flash buffer
+async function flush_fast_write()
+{
+    if (fast_write_buffer_used)
+    {
+        await writeSerialPortAsync(fast_write_buffer.subarray(0, fast_write_buffer_used));
+        fast_write_buffer_used = 0;
+    }
+}
+
+// Write a byte to the fast flash buffer
+async function fast_write(inbyte)
+{
+    // Convert the incoming character to a hex nibble
+    let nibble = -1;
+    if (inbyte >= 0x30 && inbyte <= 0x39)
+        nibble = inbyte - 0x30;
+    else if (inbyte >= 0x41 && inbyte <= 0x46)
+        nibble = inbyte - 0x41 + 0xA;
+    else if (inbyte >= 0x61 && inbyte <= 0x66)
+        nibble = inbyte - 0x61 + 0xA;
+
+    // Can only switch to binary if we can replace the ':' with '='.  Check we just wrote that...
+    if (fast_unsent_byte_count == 0 && (fast_write_buffer_used == 0 || fast_write_buffer[fast_write_buffer_used-1] != 0x3A))
+    {
+        nibble = -1;
+    }
+
+    // If it wasn't a hex digit, then revert to text mode
+    if (nibble == -1)
+    {
+        // Odd number of nibbles.  Oh no!
+        if (fast_unsent_nibble >= 0)
+            fail(".hex file not compatible with fast mode- odd number of consecutive hex digits")
+
+        // Back fill the binary length
+        if (fast_unsent_byte_count)
+        {
+            fast_write_buffer[fast_write_buffer_used - fast_unsent_byte_count - 1] = fast_unsent_byte_count;
+            fast_unsent_byte_count = 0;
+        }
+
+        // Binary data must be terminated with a CR, LF of Ctrl+Z.  Insert a Ctrl+Z if necessary
+        // (Not the typical case)
+        if (inbyte != 0x13 && inbyte != 0x10)
+        {
+            fast_write_buffer[fast_write_buffer_used++] = inbyte;
+        }
+
+        // Write non-hex bytes
+        fast_write_buffer[fast_write_buffer_used++] = inbyte;
+
+        // Flush the buffer if it's getting fullish
+        if (fast_write_buffer_used > 2048)
+        {
+            await flush_fast_write();
+        }
+        return;
+    }
+
+    // If this is the first nibble, store it until we get the second.
+    if (fast_unsent_nibble == -1)
+    {
+        // Just store it for now
+        fast_unsent_nibble = nibble;
+        return;
+    }
+
+    // If this is the first complete byte in the sequence, then change the ":"
+    // to "=" and reserve room to back fill the length later.
+    if (fast_unsent_byte_count == 0)
+    {
+        // Switch to "=""            
+        fast_write_buffer[fast_write_buffer_used-1] = 0x3D;
+
+        // Reserve room
+        fast_write_buffer_used++;
+    }
+
+    // Append the binary byte to the buffer
+     fast_write_buffer[fast_write_buffer_used++] = ((fast_unsent_nibble << 4) | nibble);
+    fast_unsent_nibble = -1;
+    fast_unsent_byte_count++;
+
+    // Check
+    if (fast_unsent_byte_count > 255)
+        fail(".hex file is incompatible with fast mode, use --nofast switch");
+}
+
+
+// Send the reboot magic string
+async function sendRebootMagic()
+{   
+    // Open serial port
+    await openSerialPortAsync(userBaud);
+
+    // Send it
+    stdout.write(`Sending reboot magic '${rebootMagic}'...`)
+    await writeSerialPortAsync(rebootMagic);
+    stdout.write(`ok\n`);
+
+    // Delay
+    if (rebootDelay)
+    {
+        stdout.write(`Delaying for ${rebootDelay}ms while rebooting...`);
+        await delay(rebootDelay);
+        stdout.write(`ok\n`);
+    }
+}
+
+// Flash the device with the hex file
+async function flashDevice()
+{   
+    // Open serial port
+    await openSerialPortAsync(flashBaud);
+
+    let resetBuf = Buffer.alloc(257);
+    resetBuf[256] = 'R'.charCodeAt(0);
+
+    // Wait for `IHEX` from device as ack it's ready
+    if (waitForAck)
+    {
+        // Send a reset command 
+        // (requires the newest version of the booloader kernal)
+        stdout.write(`Sending reset command...`);
+
+        // Setup receive listener
+        let resolveDeviceReady;
+        port.on('data', function(data) {
+
+            let str = data.toString(`utf8`);
+            if (str.includes(`IHEX`))
+            {
+                stdout.write(`ok\n`);
+
+                if (!noFast)
+                {
+                    // If the device responds with IHEX-F it's got
+                    // the fast bootloader so switch to that mode unless
+                    // disabled by command line switch
+                    if (str.includes(`IHEX-F`))
+                    {
+                        stdout.write("Fast mode enabled\n");
+                        fastMode = true;
+                    }
+                }
+
+                if (resolveDeviceReady)
+                    resolveDeviceReady();
+            }
+
+        });
+
+        // Send reset command
+        await writeSerialPortAsync(resetBuf);
+
+        // Set the reset
+        stdout.write(`ok\n`);
+        stdout.write(`Waiting for device...`);
+
+        // Wait for it
+        await new Promise((resolve, reject) => {
+            resolveDeviceReady = resolve;
+        });
+        port.removeAllListeners('data');
+    }
+    else
+    {
+        // Send reset command
+        await writeSerialPortAsync(resetBuf);
+    }
+
+    // Copy to device
+    let startTime = new Date().getTime();
+    stdout.write(`Sending`);
+    let fd = fs.openSync(hexFile, `r`);    
+    let buf = Buffer.alloc(4096);
+    while (true)
+    {
+        // Read from hex file
+        let bytesRead = fs.readSync(fd, buf, 0, buf.length);
+        if (bytesRead == 0)
+            break;
+
+        if (fastMode)
+        {
+            // In fast mode, push each byte through the fast
+            // flash state machine
+            for (let i=0; i<bytesRead; i++)
+            {
+                await fast_write(buf[i]);
+            }
+        }
+        else
+        {
+            // Write directly to serial port
+            await writeSerialPortAsync(buf.subarray(0, bytesRead));
+        }
+        stdout.write(`.`);
+    }
+    fs.closeSync(fd);
+
+    // Flush the fast flash buffer
+    if (fastMode)
+    {
+        flush_fast_write();
+    }
+
+    // Done
+    stdout.write(`ok\n`);
+
+    // Log time
+    let elapsedTime = new Date().getTime() - startTime;
+    stdout.write(`Finished in ${((elapsedTime / 1000).toFixed(1))} seconds.\n`);
+}
+
+
+// Send the go command and wait for ack
+async function sendGoCommand()
+{   
+    // Open serial port
+    await openSerialPortAsync(flashBaud);
+
+    // Send it
+    stdout.write(`Sending go command...`)
+
+    // Wait until we receive `--` indicating device received the go command
+    if (waitForAck)
+    {
+        // Setup receive listener
+        let resolveAck;
+        port.on('data', function(data) {
+
+            let str = data.toString(`utf8`);
+            if (str.includes(`\r--\r\n\n`))
+            {
+                stdout.write(`ok\n`);
+                resolveAck();
+            }
+
+        });
+
+        // Send command
+        await writeSerialPortAsync('g');
+
+        // Wait for it
+        await new Promise((resolve, reject) => {
+            resolveAck = resolve;
+        });
+        port.removeAllListeners('data');
+    }
+    else
+    {
+        await writeSerialPortAsync('g');
+        stdout.write(`ok\n`);
+    }
+}
+
+// Start serial monitor
+async function startMonitor()
+{   
+    // Open serial port
+    await openSerialPortAsync(userBaud);
+
+    // Setup receive listener
+    let resolveDeviceReady;
+    port.on('data', function(data) {
+
+        var str = data.toString(`utf8`);
+        stdout.write(str);
+    });
+
+    // Wait for the never delivered promise to keep alive
+    await new Promise((resolve) => { });
+}
+
+// Async delay helper
+async function delay(period)
+{
+    return new Promise((resolve) => {
+        setTimeout(resolve, period);
+    })
+}
+
+// Help!
+function showHelp()
+{
+    console.log(`Usage: node flashy <serialport> [<hexfile>] [options]`);
+    console.log(`All-In-One Reboot, Flash and Monitor Tool`);
+    console.log(``);
+    console.log(`<serialport>       Serial port to write to`);
+    console.log(`<hexfile>          The .hex file to write (optional)`);
+    console.log(`--flashbaud:<N>    Baud rate for flashing (default=115200)`);
+    console.log(`--userbaud:<N>     Baud rate for monitor and reboot magic (default=115200)`);
+    console.log(`--noack            Send without checking if device is ready`);
+    console.log(`--fast             Force fast mode flash`);
+    console.log(`--nofast           Disable fast mode`);
+    console.log(`--nogo             Don't send the go command after flashing`);
+    console.log(`--go               Send the go command, even if not flashing`);
+    console.log(`--reboot:<magic>   Sends a magic reboot string at user baud before flashing`);
+    console.log(`--rebootdelay:<ms> Delay after sending reboot magic (only needed with --noack)`);
+    console.log(`--monitor          Monitor serial port`);
+    console.log(`--help             Show this help`);
+}
+
+// Abort with message
+function fail(msg)
+{
+    console.error(msg);
+    console.error(`Run with --help for instructions`);
+    process.exit(7);
+}
+
+// Parse command line args
+function parseCommandLine()
+{
+    for (let i=2; i<process.argv.length; i++)
+    {   
+        let arg = process.argv[i];
+        if (arg.startsWith(`--`))
+        {
+            let parts = arg.substr(2).split(':');
+            let sw = parts[0];
+            let value = parts[1];
+            switch (sw.toLowerCase())
+            {
+                case `flashbaud`:
+                    flashBaud = Number(value);
+                    break;
+
+                case `noack`:
+                    waitForAck = false;
+                    break;
+
+                case `help`:
+                    showHelp();
+                    process.exit(0);
+
+                case `nogo`:
+                    nogoSwitch = true;
+                    break;
+
+                case `go`:
+                    goSwitch = true;
+                    break;
+
+                case `reboot`:
+                    rebootMagic = value;
+                    break;
+
+                case `rebootdelay`:
+                    rebootDelay = Number(value);
+                    break;
+
+                case `monitor`:
+                    monitor = true;
+                    break;
+
+                case `userbaud`:
+                    userBaud = Number(value);
+                    break;
+
+                case `fast`:
+                    fastMode = true;
+                    break;
+
+                case `nofast`:
+                    noFast = true;
+                    break;
+
+                default:
+                    fail(`Unknown switch --${sw}`);
+            }
+        }
+        else
+        {
+            // First arg is serial port name
+            if (serialPortName == null)
+            {
+                serialPortName = arg;
+                continue;
+            }
+            else if (hexFile == null)
+            {
+                // Second arg is the .hex file
+                hexFile = arg;
+                
+                // Sanity check
+                if (!arg.toLowerCase().endsWith('.hex'))
+                {
+                    console.error(`Warning: hex file '${arg}' doesn't have .hex extension.`);
+                }
+            }
+            else
+            {
+                fail(`Too many command line args: '${arg}'`);
+            }
+        }
+    }
+
+    // Can't do anything without a serial port
+    if (!serialPortName)
+        fail(`No serial port specified`);
+}
+
+
+// Run async
+(async function()
+{
+    // parse the command line
+    parseCommandLine();
+
+    // Reboot
+    if (rebootMagic)
+        await sendRebootMagic();
+
+    // Flash
+    if (hexFile)
+        await flashDevice();
+
+    // Go
+    if ((hexFile && !nogoSwitch) || (!hexFile && goSwitch))
+        await sendGoCommand();
+
+    // Monitor
+    if (monitor)
+        await startMonitor();
+
+    // Finished
+    await closeSerialPortAsync();
+    stdout.write(`Done!\n`);
+})();

--- a/tools/flashy/package.json
+++ b/tools/flashy/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "flasher",
+  "version": "1.0.0",
+  "description": "All-In-One Reboot, Flash and Monitor Tool",
+  "main": "flasher.js",
+  "dependencies": {
+    "serialport": "^9.0.4"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
This PR includes a new bootloader and flasher script that improves flash operations in a couple of ways:

* Fast flash mode almost twice as fast
* Pings the bootloader and waits for ack that it's ready before sending
* Waits for ack after sending the file instead of assuming it succeeded
* Can reset the bootloader from a failed or canceled previous load 
* Can send magic reboot strings
* Can start monitoring after the flash (including switching baud rates if necessary)
* Allows flashing from inside WSL2 machines (that don't support serial ports)

In addition to the the flash script itself, there's also:

* Changes to the bootloader to support ping/ack/reset and fast flash mode
* An updated version of Rules.mk to optionally enable the new flasher and to support WSL
* Updated documentation on the bootloader describing how to enable it
* Updated windows build documentation explaining how to use it under WSL 2

The new script also benefits from being written in NodeJS instead of Python. I couldn't get python3.exe to launch from inside a WSL machine. Also python3 on some Windows 10 machines can be frustratingly slow to start - 5 to 10 seconds, so this is an alternative if suffering from this issue.

There are a fair few changes here but I think they're mostly low risk. Nothing touches the core circle library and most changes only take effect when enabled.  The changes to bootloader are probably the highest risk, but they only take effect when it receives an "=" character (to switch into high-speed mode) which standard hex files never include - so the old flasher should not be impacted.  I've tested the old flasher tool with the new bootloader and it works fine.