### PR TITLE
Added GCC compile time checks for CString::Format and CLogger::Write printf style arguments

### DIFF
--- a/include/circle/logger.h
+++ b/include/circle/logger.h
@@ -55,7 +55,8 @@ public:
 
 	void SetNewTarget (CDevice *pTarget);
 
-	void Write (const char *pSource, TLogSeverity Severity, const char *pMessage, ...);
+	void Write (const char *pSource, TLogSeverity Severity, const char *pMessage, ...)
+		__attribute__ ((format (printf, 4, 5)));
 	void WriteV (const char *pSource, TLogSeverity Severity, const char *pMessage, va_list Args);
 
 	// does not allocate memory, for critical (low memory) messages

--- a/include/circle/string.h
+++ b/include/circle/string.h
@@ -42,7 +42,9 @@ public:
 
 	int Replace (const char *pOld, const char *pNew); // returns number of occurrences
 
-	void Format (const char *pFormat, ...);		// supports only a small subset of printf(3)
+	
+	void Format (const char *pFormat, ...) 		// supports only a small subset of printf(3)
+		__attribute__ ((format (printf, 2, 3)));
 	void FormatV (const char *pFormat, va_list Args);
 
 private:


### PR DESCRIPTION
There are other places that this could be used, but these seemed the most important two.