### PR TITLE
PWM audio: allow using gpio18/19 for output.

### DIFF
--- a/include/circle/sysconfig.h
+++ b/include/circle/sysconfig.h
@@ -104,12 +104,21 @@
 #define GPU_L2_CACHE_ENABLED
 #endif
 
-// USE_PWM_AUDIO_ON_ZERO can be defined to use GPIO12/13 for PWM audio
-// output on RPi Zero (W). Some external circuit is needed to use this.
+// USE_PWM_AUDIO_ON_ZERO can be defined to use GPIO12/13 (or 18/19) for
+// PWM audio output on RPi Zero (W). Some external circuit is needed to
+// use this.
 // WARNING: Do not feed voltage into these GPIO pins with this option
 //          defined on a RPi Zero, because this may destroy the pins.
 
 //#define USE_PWM_AUDIO_ON_ZERO
+
+// The left PWM audio output pin is by default GPIO12. The following
+// define moves it to GPIO18.
+//#define USE_GPIO18_FOR_LEFT_PWM_ON_ZERO
+
+// The right PWM audio output pin is by default GPIO13. The following
+// define moves it to GPIO19.
+//#define USE_GPIO19_FOR_RIGHT_PWM_ON_ZERO
 
 #endif
 

--- a/lib/machineinfo.cpp
+++ b/lib/machineinfo.cpp
@@ -349,7 +349,11 @@ unsigned CMachineInfo::GetGPIOPin (TGPIOVirtualPin Pin) const
 		if (   m_MachineModel == MachineModelZero
 		    || m_MachineModel == MachineModelZeroW)
 		{
+#ifdef USE_GPIO18_FOR_LEFT_PWM_ON_ZERO
+			return 18;
+#else
 			return 12;
+#endif // USE_GPIO18_FOR_LEFT_PWM_ON_ZERO
 		}
 #endif
 		if (m_MachineModel <= MachineModelBRelease2MB512)
@@ -374,7 +378,11 @@ unsigned CMachineInfo::GetGPIOPin (TGPIOVirtualPin Pin) const
 		if (   m_MachineModel == MachineModelZero
 		    || m_MachineModel == MachineModelZeroW)
 		{
+#ifdef USE_GPIO19_FOR_RIGHT_PWM_ON_ZERO
+			return 19;
+#else
 			return 13;
+#endif // USE_GPIO19_FOR_RIGHT_PWM_ON_ZERO
 		}
 #endif
 		if (m_MachineModel <= MachineModelBRelease2MB512)

--- a/lib/pwmsoundbasedevice.cpp
+++ b/lib/pwmsoundbasedevice.cpp
@@ -156,8 +156,16 @@ CPWMSoundBaseDevice::CPWMSoundBaseDevice (CInterruptSystem *pInterrupt,
 	m_pInterruptSystem (pInterrupt),
 	m_nChunkSize (nChunkSize),
 	m_nRange ((CLOCK_RATE + nSampleRate/2) / nSampleRate),
+#ifdef USE_GPIO18_FOR_LEFT_PWM_ON_ZERO
+	m_Audio1 (GPIOPinAudioLeft, GPIOModeAlternateFunction5),
+#else
 	m_Audio1 (GPIOPinAudioLeft, GPIOModeAlternateFunction0),
+#endif // USE_GPIO18_FOR_LEFT_PWM_ON_ZERO
+#ifdef USE_GPIO19_FOR_RIGHT_PWM_ON_ZERO
+	m_Audio2 (GPIOPinAudioRight, GPIOModeAlternateFunction5),
+#else
 	m_Audio2 (GPIOPinAudioRight, GPIOModeAlternateFunction0),
+#endif // USE_GPIO19_FOR_RIGHT_PWM_ON_ZERO
 	m_Clock (GPIOClockPWM),
 	m_bIRQConnected (FALSE),
 	m_State (PWMSoundIdle),


### PR DESCRIPTION
This PR adds two more #defines which allow moving pwm audio output pins from 12/13 to 18/19 (individually).
Arguably this is only useful on a Pi Zero (the others have a hardwired jack), but I have a device that uses those (namely a [GPi Case](http://retroflag.com/GPi-CASE.html) I mentioned in another Issue).
I tested it with your pwm audio sample code and it works as expected.
Feel free to reject if you feel it just adds unnecessary clutter to sysconfig.h.