### PR TITLE
Added Ltd FT2232C/D/H Dual UART/FIFO IC to list of ft231x devices

### DIFF
--- a/lib/usb/usbserialft231x.cpp
+++ b/lib/usb/usbserialft231x.cpp
@@ -71,7 +71,7 @@ boolean CUSBSerialFT231XDevice::Configure (void)
 	{
 		type = "FT232RL";
 	}
-	else if (deviceDesc->bcdDevice == 0x900)
+	else if (deviceDesc->bcdDevice == 0x700 || deviceDesc->bcdDevice == 0x900)
 	{
 		type = "FT232H";
 	}
@@ -242,6 +242,7 @@ const TUSBDeviceID *CUSBSerialFT231XDevice::GetDeviceIDTable (void)
 	static const TUSBDeviceID DeviceIDTable[] =
 	{
 		{ USB_DEVICE (0x0403, 0x6001) },
+		{ USB_DEVICE (0x0403, 0x6010) },
 		{ USB_DEVICE (0x0403, 0x6014) },	// FT232H
 		{ USB_DEVICE (0x0403, 0x6015) },
 		{ }


### PR DESCRIPTION
Linux reports the device as:
Bus 002 Device 005: ID 0403:6010 Future Technology Devices International, Ltd FT2232C/D/H Dual UART/FIFO IC

One of the Sidekick64 network testers has this device and I patched it into to the source. He reports it to be working fine. Would be cool if you could at this to circle, Rene! Thank you in advance!