### PR TITLE
Complete TODO item of ANSI reverse code, on way to ANSI colour support.

### DIFF
--- a/doc/screen.txt
+++ b/doc/screen.txt
@@ -15,6 +15,7 @@ ESCAPE SEQUENCES
 \E[0m		End of bold or half bright mode
 \E[1m		Start bold mode
 \E[2m		Start half bright mode
+\E[7m		Start reverse video mode
 ^I		Move to next hardware tab
 \E[?25h		Normal cursor visible
 \E[?25l		Cursor invisible

--- a/doc/screen.txt
+++ b/doc/screen.txt
@@ -16,6 +16,7 @@ ESCAPE SEQUENCES
 \E[1m		Start bold mode
 \E[2m		Start half bright mode
 \E[7m		Start reverse video mode
+\E[27m		End reverse video mode
 ^I		Move to next hardware tab
 \E[?25h		Normal cursor visible
 \E[?25l		Cursor invisible

--- a/include/circle/screen.h
+++ b/include/circle/screen.h
@@ -83,6 +83,7 @@ struct TScreenStatus
 	unsigned	nCursorY;
 	boolean		bCursorOn;
 	TScreenColor	Color;
+	TScreenColor	BackgroundColor;
 	boolean		bInsertOn;
 	unsigned	nParam1;
 	unsigned	nParam2;
@@ -136,6 +137,7 @@ public:
 	/// \param nPosX X-Position of the pixel (based on 0)
 	/// \param nPosY Y-Position of the pixel (based on 0)
 	/// \param Color The color to be set (value depends on screen DEPTH)
+	/// \param BackgroundColor The color to be set (value depends on screen DEPTH)
 	void SetPixel (unsigned nPosX, unsigned nPosY, TScreenColor Color);
 	/// \brief Get the color value of a pixel
 	/// \param nPosX X-Position of the pixel (based on 0)
@@ -206,6 +208,7 @@ private:
 	unsigned	 m_nCursorY;
 	boolean		 m_bCursorOn;
 	TScreenColor	 m_Color;
+	TScreenColor	 m_BackgroundColor;
 	boolean		 m_bInsertOn;
 	unsigned	 m_nParam1;
 	unsigned	 m_nParam2;

--- a/include/circle/screen.h
+++ b/include/circle/screen.h
@@ -84,6 +84,7 @@ struct TScreenStatus
 	boolean		bCursorOn;
 	TScreenColor	Color;
 	TScreenColor	BackgroundColor;
+	boolean		ReverseAttribute;
 	boolean		bInsertOn;
 	unsigned	nParam1;
 	unsigned	nParam2;
@@ -137,7 +138,6 @@ public:
 	/// \param nPosX X-Position of the pixel (based on 0)
 	/// \param nPosY Y-Position of the pixel (based on 0)
 	/// \param Color The color to be set (value depends on screen DEPTH)
-	/// \param BackgroundColor The color to be set (value depends on screen DEPTH)
 	void SetPixel (unsigned nPosX, unsigned nPosY, TScreenColor Color);
 	/// \brief Get the color value of a pixel
 	/// \param nPosX X-Position of the pixel (based on 0)
@@ -167,6 +167,8 @@ private:
 	void DeleteLines (unsigned nCount);
 	void DisplayChar (char chChar);
 	void EraseChars (unsigned nCount);
+	TScreenColor GetTextBackgroundColor (void);
+	TScreenColor GetTextColor (void);
 	void InsertLines (unsigned nCount);
 	void InsertMode (boolean bBegin);
 	void NewLine (void);
@@ -209,6 +211,7 @@ private:
 	boolean		 m_bCursorOn;
 	TScreenColor	 m_Color;
 	TScreenColor	 m_BackgroundColor;
+	boolean		 m_ReverseAttribute;
 	boolean		 m_bInsertOn;
 	unsigned	 m_nParam1;
 	unsigned	 m_nParam2;

--- a/lib/screen.cpp
+++ b/lib/screen.cpp
@@ -935,7 +935,7 @@ void CScreenDevice::SetPixel (unsigned nPosX, unsigned nPosY, TScreenColor Color
 
 TScreenColor CScreenDevice::GetPixel (unsigned nPosX, unsigned nPosY)
 {
-	return m_BackgroundColor;
+	return BLACK_COLOR;
 }
 
 void CScreenDevice::Rotor (unsigned nIndex, unsigned nCount)

--- a/lib/screen.cpp
+++ b/lib/screen.cpp
@@ -51,6 +51,7 @@ CScreenDevice::CScreenDevice (unsigned nWidth, unsigned nHeight, boolean bVirtua
 	m_nCursorY (0),
 	m_bCursorOn (TRUE),
 	m_Color (NORMAL_COLOR),
+	m_BackgroundColor (BLACK_COLOR),
 	m_bInsertOn (FALSE),
 	m_bUpdated (FALSE)
 #ifdef SCREEN_DMA_BURST_LENGTH
@@ -168,6 +169,7 @@ TScreenStatus CScreenDevice::GetStatus (void)
 	Status.nCursorY   = m_nCursorY;
 	Status.bCursorOn  = m_bCursorOn;
 	Status.Color      = m_Color;
+	Status.BackgroundColor      = m_BackgroundColor;
 	Status.bInsertOn  = m_bInsertOn;
 	Status.nParam1    = m_nParam1;
 	Status.nParam2    = m_nParam2;
@@ -203,6 +205,7 @@ boolean CScreenDevice::SetStatus (const TScreenStatus &Status)
 	m_nCursorY   = Status.nCursorY;
 	m_bCursorOn  = Status.bCursorOn;
 	m_Color      = Status.Color;
+	m_BackgroundColor      = Status.BackgroundColor;
 	m_bInsertOn  = Status.bInsertOn;
 	m_nParam1    = Status.nParam1;
 	m_nParam2    = Status.nParam2;
@@ -543,7 +546,7 @@ void CScreenDevice::ClearDisplayEnd (void)
 	
 	while (nSize--)
 	{
-		*pBuffer++ = BLACK_COLOR;
+		*pBuffer++ = m_BackgroundColor;
 	}
 }
 
@@ -723,7 +726,14 @@ void CScreenDevice::SetStandoutMode (unsigned nMode)
 		m_Color = HALF_COLOR;
 		break;
 
-	case 7:				// TODO: reverse mode
+	case 7:
+		TScreenColor    tmp_Color;
+
+		tmp_Color = m_Color;
+		m_Color = m_BackgroundColor;
+		m_BackgroundColor = tmp_Color;
+		break;
+
 	default:
 		break;
 	}
@@ -769,7 +779,7 @@ void CScreenDevice::Scroll (void)
 	nSize = m_nPitch * nLines * sizeof (TScreenColor) / sizeof (u32);
 	while (nSize--)
 	{
-		*pTo++ = BLACK_COLOR;
+		*pTo++ = m_BackgroundColor;
 	}
 }
 
@@ -780,7 +790,7 @@ void CScreenDevice::DisplayChar (char chChar, unsigned nPosX, unsigned nPosY, TS
 		for (unsigned x = 0; x < m_CharGen.GetCharWidth (); x++)
 		{
 			SetPixel (nPosX + x, nPosY + y,
-				  m_CharGen.GetPixel (chChar, x, y) ? Color : BLACK_COLOR);
+				  m_CharGen.GetPixel (chChar, x, y) ? Color : m_BackgroundColor);
 		}
 	}
 }
@@ -791,7 +801,7 @@ void CScreenDevice::EraseChar (unsigned nPosX, unsigned nPosY)
 	{
 		for (unsigned x = 0; x < m_CharGen.GetCharWidth (); x++)
 		{
-			SetPixel (nPosX + x, nPosY + y, BLACK_COLOR);
+			SetPixel (nPosX + x, nPosY + y, m_BackgroundColor);
 		}
 	}
 }
@@ -807,13 +817,13 @@ void CScreenDevice::InvertCursor (void)
 	{
 		for (unsigned x = 0; x < m_CharGen.GetCharWidth (); x++)
 		{
-			if (GetPixel (m_nCursorX + x, m_nCursorY + y) == BLACK_COLOR)
+			if (GetPixel (m_nCursorX + x, m_nCursorY + y) == m_BackgroundColor)
 			{
 				SetPixel (m_nCursorX + x, m_nCursorY + y, m_Color);
 			}
 			else
 			{
-				SetPixel (m_nCursorX + x, m_nCursorY + y, BLACK_COLOR);
+				SetPixel (m_nCursorX + x, m_nCursorY + y, m_BackgroundColor);
 			}
 		}
 	}
@@ -836,7 +846,7 @@ TScreenColor CScreenDevice::GetPixel (unsigned nPosX, unsigned nPosY)
 		return m_pBuffer[m_nPitch * nPosY + nPosX];
 	}
 	
-	return BLACK_COLOR;
+	return m_BackgroundColor;
 }
 
 void CScreenDevice::Rotor (unsigned nIndex, unsigned nCount)
@@ -915,7 +925,7 @@ void CScreenDevice::SetPixel (unsigned nPosX, unsigned nPosY, TScreenColor Color
 
 TScreenColor CScreenDevice::GetPixel (unsigned nPosX, unsigned nPosY)
 {
-	return BLACK_COLOR;
+	return m_BackgroundColor;
 }
 
 void CScreenDevice::Rotor (unsigned nIndex, unsigned nCount)

--- a/lib/screen.cpp
+++ b/lib/screen.cpp
@@ -811,7 +811,7 @@ void CScreenDevice::EraseChar (unsigned nPosX, unsigned nPosY)
 	{
 		for (unsigned x = 0; x < m_CharGen.GetCharWidth (); x++)
 		{
-			SetPixel (nPosX + x, nPosY + y, GetTextBackgroundColor ());
+			SetPixel (nPosX + x, nPosY + y, m_BackgroundColor);
 		}
 	}
 }

--- a/sample/03-screentext/kernel.cpp
+++ b/sample/03-screentext/kernel.cpp
@@ -76,7 +76,7 @@ TShutdownMode CKernel::Run (void)
 		}
 
 		CString Message;
-		Message.Format ("%02X: \'%c\' ", (unsigned) chChar, chChar);
+		Message.Format ("%02X: \'\u001b[7m%c\u001b[7m\' ", (unsigned) chChar, chChar);
 		
 		m_Screen.Write ((const char *) Message, Message.GetLength ());
 	}

--- a/sample/03-screentext/kernel.cpp
+++ b/sample/03-screentext/kernel.cpp
@@ -76,7 +76,7 @@ TShutdownMode CKernel::Run (void)
 		}
 
 		CString Message;
-		Message.Format ("%02X: \'\u001b[7m%c\u001b[7m\' ", (unsigned) chChar, chChar);
+		Message.Format ("%02X: \'\u001b[7m%c\u001b[0m\' ", (unsigned) chChar, chChar);
 		
 		m_Screen.Write ((const char *) Message, Message.GetLength ());
 	}


### PR DESCRIPTION
Hi there, this is an "experimental commit" to to see if you approve of the "BackgroundColor" property in screen.cpp.

This is a partial port of my own private repo with full 16colour ANSI support, Fore and Background.  But mostly I want to check the style meets your approval.

I've chosen to do this facet first as I noticed you'd marked it as a TODO item in the source code.

If this doesn't meet with your approval I'd sorely like a tip to get it to "pass muster", so I can change the style, and then upgrade the rest of my code to match.  I've also checked this with `circle-stdlib` and `printf` et al is working fine too.

I'll submit a pull request to `circle-stdlib` with a full colour demo, once I've got this all merged into your main repo here.

I've also, as a second commit in this pull request, modified the 03-screentext demo to inverse the actual characters in the grid, as an example of using the control code for inverse.  You, obviously, don't have to take any of these - but the second commit (the demo one) is "extra optional".

Looking forward to your response, before I continue, and send you a pull request for the remainder of the 16colour work.
Hopefully you accept, but - of course - feel free to do with as you wish. Any "stylistic" edits/input you make I will do my best to adhere to on further pull requests.

-Dx