### PR TITLE
addon/SDCard: don't check the result of GetTag so it can work on QEMU

### DIFF
--- a/addon/SDCard/sdhost.cpp
+++ b/addon/SDCard/sdhost.cpp
@@ -262,10 +262,7 @@ int CSDHOSTDevice::set_sdhost_clock (u32 msg[3])
 	memcpy (SetSDHOSTClock.msg, msg, sizeof *msg);
 
 	CBcmPropertyTags Tags;
-	if (!Tags.GetTag (PROPTAG_SET_SDHOST_CLOCK, &SetSDHOSTClock, sizeof SetSDHOSTClock, 3*4))
-	{
-		return -ENOTSUP;
-	}
+	Tags.GetTag (PROPTAG_SET_SDHOST_CLOCK, &SetSDHOSTClock, sizeof SetSDHOSTClock, 3*4);
 
 	memcpy (msg, SetSDHOSTClock.msg, sizeof *msg);
 


### PR DESCRIPTION
According to [qemu/hw/misc/bcm2835_property.c](https://gitlab.com/qemu-project/qemu/-/blob/master/hw/misc/bcm2835_property.c), QEMU doesn't implemented the property tag `PROPTAG_SET_SDHOST_CLOCK`, but it does implement an SDHost. Remove the code that checks the result of `GetTag` can make SDHost driver work on QEMU, like [what `raspberrypi/linux` does](https://github.com/raspberrypi/linux/blob/rpi-5.10.y/drivers/mmc/host/bcm2835-sdhost.c#L2127).