### PR TITLE
Minor update regarding how to build circle-stdlib

### DIFF
--- a/doc/stdlib-support.txt
+++ b/doc/stdlib-support.txt
@@ -16,10 +16,10 @@ following project (a newlib port for Circle) by Stephan Muehlstrasser:
 
 	https://github.com/smuehlst/circle-stdlib
 
-Circle is included as a Git sub-module into this project, which provides a build
-script (build.bash), which allows building all required libraries (including the
+Circle is included as a Git sub-module into this project, which provides a configure
+script and makefiles to build all required libraries (including the
 Circle libraries) to use C standard library functions in Circle. The project
-contains also specific sample programs, which demonstrate, how this support can
+contains also specific sample programs, which demonstrate how this support can
 be used. Please see the documentation of this project for details!
 
 Some toolchains provide C++ standard library support, which have been build


### PR DESCRIPTION
Replaced an obsolete reference to the build.bash script with a reference to the current configure script and makefiles.