### PR TITLE
FIXED:pwmoutput value of ARM_PWM_CTL_MSEN2 is incorrect

### DIFF
--- a/lib/pwmoutput.cpp
+++ b/lib/pwmoutput.cpp
@@ -41,7 +41,7 @@
 #define ARM_PWM_CTL_SBIT2	(1 << 11)
 #define ARM_PWM_CTL_POLA2	(1 << 12)
 #define ARM_PWM_CTL_USEF2	(1 << 13)
-#define ARM_PWM_CTL_MSEN2	(1 << 14)
+#define ARM_PWM_CTL_MSEN2	(1 << 15)
 
 //
 // PWM status register


### PR DESCRIPTION
Hi! Thank you for the wonderful library.

PWM_CHANNEL2 seems not working well. I tried to fix it.
https://www.raspberrypi.org/app/uploads/2012/02/BCM2835-ARM-Peripherals.pdf
Page 142


