### PR TITLE
Improve energy efficiency of AArch64 lock acquire

### DIFF
--- a/lib/spinlock.cpp
+++ b/lib/spinlock.cpp
@@ -74,7 +74,13 @@ void CSpinLock::Acquire (void)
 			"mov x1, %0\n"
 			"mov w2, #1\n"
 			"prfm pstl1keep, [x1]\n"
-			"1: ldaxr w3, [x1]\n"
+#ifdef SPINLOCK_SAVE_POWER
+			"sevl\n"
+			"1: wfe\n"
+#else
+			"1:\n"
+#endif
+			"ldaxr w3, [x1]\n"
 			"cbnz w3, 1b\n"
 			"stxr w3, w2, [x1]\n"
 			"cbnz w3, 1b\n"


### PR DESCRIPTION
Hi Rene!

This is a trivial change to the spinlock assembly implementation that tries to improve energy efficiency on AArch64.

From the commit message:

The 32-bit implementation of the spinlock Acquire() function uses a "wfe" instruction to send the core to sleep if it can't acquire a lock, and the corresponding Release() function will send an event with the "sev" instruction to wake up waiting cores.
 
Add this sleep functionality to the 64-bit implementation to improve energy efficiency in AArch64 builds.

N.B. a "sev" instruction is not required for AArch64 Release() because an event is automatically generated (see section B2.9.6 of "Arm Architecture Reference Manual Armv8, for Armv8-A architecture profile").

---

A test app was created to measure the CPU temperature and test the energy savings of this patch - this is available at: https://github.com/dwhinham/circle/tree/spinlock-sleep-test

The test works as follows:
- Multicore kernel compiled for AArch64, Raspberry Pi 4.
- `cmdline.txt` with `fast=true` to maximise CPU clocks.
- Core 0 acquires a spinlock and runs a loop which measures the temperature every 2 seconds.
- Cores 1-3 try to acquire the spinlock, but never succeed (intentional).
- Test is run for ~30 minutes.

Before the patch, the temperature rose to **~69C** after 30 minutes because Cores 1-3 never go to sleep.
After the patch, the temperature only rises to **~59C**, a saving of 10C.

This reference provides a good explanation of how it works: https://community.arm.com/developer/ip-products/processors/f/cortex-a-forum/4273/how-to-understand-armv8-sevl-instruction-in-spin-lock
A similar implementation can be found in the Linux kernel: https://github.com/torvalds/linux/blob/c6f5d02b6a0fb91be5d656885ce02cf28952181d/arch/arm64/include/asm/spinlock.h#L57-L61