### PR TITLE
sdhost: correct gpio mode for pin 34-39

### DIFF
--- a/addon/SDCard/sdhost.cpp
+++ b/addon/SDCard/sdhost.cpp
@@ -184,7 +184,7 @@ CSDHOSTDevice::CSDHOSTDevice (CInterruptSystem *pInterruptSystem, CTimer *pTimer
 	for (unsigned i = 0; i <= 5; i++)
 	{
 		m_GPIO34_39[i].AssignPin (34+i);
-		m_GPIO34_39[i].SetMode (GPIOModeInput, FALSE);
+		m_GPIO34_39[i].SetMode (GPIOModeAlternateFunction3, FALSE);
 
 		m_GPIO48_53[i].AssignPin (48+i);
 		m_GPIO48_53[i].SetMode (GPIOModeAlternateFunction0, FALSE);


### PR DESCRIPTION
In `addon/wlan/ether4330.c`, the GPIO setting seems to be correct:

https://github.com/rsta2/circle/blob/da58255b60378ce8ee329ca66c2861d82e732562/addon/wlan/ether4330.c#L485-L495

But in `addon/SDCard/sdhost.cpp`:

https://github.com/rsta2/circle/blob/da58255b60378ce8ee329ca66c2861d82e732562/addon/SDCard/sdhost.cpp#L180-L193

The pin 34-39 are set to `GPIOModeInput` mode, which should instead be `GPIOModeAlternateFunction3`.

Setting the pin 34-39 to `GPIOModeInput` mode does not cause problem in Circle's WLAN sample app, because it will drive SD Host first to load the firmware. However, if the WLAN driver is started before the SD Host driver, the latter one will make the WLAN driver failed. In my case, we (my teammate and I) ported Circle to a microkernel OS, using the C++ classes to construct different drivers. We put the WiFi firmware into a ramdisk so we can run WLAN driver before SD driver, then the problem occurred.