### PR TITLE
Add support for Pi Zero 2 W Wi-Fi firmware

### DIFF
--- a/addon/wlan/ether4330.c
+++ b/addon/wlan/ether4330.c
@@ -290,6 +290,7 @@ static struct {
 	{ 43362, 0,	"fw_bcm40181a0.bin", config40181, 0 },
 	{ 43362, 1,	"fw_bcm40181a2.bin", config40181, 0 },
 	{ 43430, 1,	"brcmfmac43430-sdio.bin", "brcmfmac43430-sdio.txt", 0 },
+	{ 43430, 2,	"brcmfmac43436-sdio.bin", "brcmfmac43436-sdio.txt", "brcmfmac43436-sdio.clm_blob" },
 	{ 0x4345, 6, "brcmfmac43455-sdio.bin", "brcmfmac43455-sdio.txt", "brcmfmac43455-sdio.clm_blob" },
 	{ 0x4345, 9, "brcmfmac43456-sdio.bin", "brcmfmac43456-sdio.txt", "brcmfmac43456-sdio.clm_blob" },
 };

--- a/addon/wlan/firmware/Makefile
+++ b/addon/wlan/firmware/Makefile
@@ -11,6 +11,9 @@ firmware: clean
 	wget -q -O LICENCE.broadcom_bcm43xx $(BASEURL)/LICENCE.broadcom_bcm43xx?raw=true
 	wget -q -O brcmfmac43430-sdio.bin $(BASEURL)/brcm/brcmfmac43430-sdio.bin?raw=true
 	wget -q -O brcmfmac43430-sdio.txt $(BASEURL)/brcm/brcmfmac43430-sdio.txt?raw=true
+	wget -q -O brcmfmac43436-sdio.bin $(BASEURL)/brcm/brcmfmac43436-sdio.bin?raw=true
+	wget -q -O brcmfmac43436-sdio.txt $(BASEURL)/brcm/brcmfmac43436-sdio.txt?raw=true
+	wget -q -O brcmfmac43436-sdio.clm_blob $(BASEURL)/brcm/brcmfmac43436-sdio.clm_blob?raw=true
 	wget -q -O brcmfmac43455-sdio.bin $(BASEURL)/brcm/brcmfmac43455-sdio.bin?raw=true
 	wget -q -O brcmfmac43455-sdio.txt $(BASEURL)/brcm/brcmfmac43455-sdio.txt?raw=true
 	wget -q -O brcmfmac43455-sdio.clm_blob $(BASEURL)/brcm/brcmfmac43455-sdio.clm_blob?raw=true


### PR DESCRIPTION
This PR was originally going to include the machineinfo stuff aswell, but I saw you've already taken care of that! :slightly_smiling_face:

These changes get Wi-Fi working for me - everything seems to work fine; just a new chip revision and firmware blob.

The current WLAN firmware SHA in the Makefile seems new enough to contain the correct firmware.

Cheers!