### PR TITLE
Enable PWM audio via GPIO on Zero 2 W

### DIFF
--- a/include/circle/sysconfig.h
+++ b/include/circle/sysconfig.h
@@ -83,7 +83,7 @@
 
 ///////////////////////////////////////////////////////////////////////
 //
-// Raspberry Pi 1 and Zero
+// Raspberry Pi 1, Zero (W) and Zero 2 W
 //
 ///////////////////////////////////////////////////////////////////////
 
@@ -104,9 +104,13 @@
 #define GPU_L2_CACHE_ENABLED
 #endif
 
+#endif
+
+#if RASPPI == 1 || RASPPI == 3
+
 // USE_PWM_AUDIO_ON_ZERO can be defined to use GPIO12/13 (or 18/19) for
-// PWM audio output on RPi Zero (W). Some external circuit is needed to
-// use this.
+// PWM audio output on RPi Zero (W) and Zero 2 W. Some external circuit
+// is needed to use this.
 // WARNING: Do not feed voltage into these GPIO pins with this option
 //          defined on a RPi Zero, because this may destroy the pins.
 

--- a/lib/machineinfo.cpp
+++ b/lib/machineinfo.cpp
@@ -362,7 +362,8 @@ unsigned CMachineInfo::GetGPIOPin (TGPIOVirtualPin Pin) const
 	case GPIOPinAudioLeft:
 #ifdef USE_PWM_AUDIO_ON_ZERO
 		if (   m_MachineModel == MachineModelZero
-		    || m_MachineModel == MachineModelZeroW)
+		    || m_MachineModel == MachineModelZeroW
+		    || m_MachineModel == MachineModelZero2W)
 		{
 #ifdef USE_GPIO18_FOR_LEFT_PWM_ON_ZERO
 			return 18;
@@ -391,7 +392,8 @@ unsigned CMachineInfo::GetGPIOPin (TGPIOVirtualPin Pin) const
 	case GPIOPinAudioRight:
 #ifdef USE_PWM_AUDIO_ON_ZERO
 		if (   m_MachineModel == MachineModelZero
-		    || m_MachineModel == MachineModelZeroW)
+		    || m_MachineModel == MachineModelZeroW
+		    || m_MachineModel == MachineModelZero2W)
 		{
 #ifdef USE_GPIO19_FOR_RIGHT_PWM_ON_ZERO
 			return 19;
@@ -481,7 +483,8 @@ boolean CMachineInfo::ArePWMChannelsSwapped (void) const
 {
 	return    m_MachineModel >= MachineModelAPlus
 	       && m_MachineModel != MachineModelZero
-	       && m_MachineModel != MachineModelZeroW;
+	       && m_MachineModel != MachineModelZeroW
+	       && m_MachineModel != MachineModelZero2W;
 }
 
 unsigned CMachineInfo::AllocateDMAChannel (unsigned nChannel)


### PR DESCRIPTION
These commits allow you to use `USE_PWM_AUDIO_ON_ZERO` and `USE_GPIO{18|19}_FOR_{LEFT|RIGHT}_PWM_ON_ZERO` to gain PWM audio output on the new Zero 2 W.

In `sysconfig.h`, I wrapped the PWM `#defines` in a `#if RASPPI == 1 || RASPPI == 3` block so that they are picked up when compiling with `RASPPI=3` as we do for Zero 2 W. This seemed to be the simplest way to achieve this, but if you'd prefer another way I'd be more than happy to respond to your feedback.

Cheers!