### PR TITLE
Add options for rotated or mirrored display

### DIFF
--- a/addon/display/sample/ssd1306/kernel.cpp
+++ b/addon/display/sample/ssd1306/kernel.cpp
@@ -35,13 +35,17 @@
 
 static const char FromKernel[] = "kernel";
 
+// Set to true to enable rotated or mirrored displays
+#define ROTATED   false
+#define MIRRORED  false
+
 CKernel::CKernel (void)
 :	m_Screen (m_Options.GetWidth (), m_Options.GetHeight ()),
 	m_Timer (&m_Interrupt),
 	m_Logger (m_Options.GetLogLevel (), &m_Timer),
 	m_USBHCI (&m_Interrupt, &m_Timer),
 	m_I2CMaster (I2C_MASTER_DEVICE),
-	m_LCD (WIDTH, HEIGHT, &m_I2CMaster, I2C_ADDR)
+	m_LCD (WIDTH, HEIGHT, &m_I2CMaster, I2C_ADDR, ROTATED, MIRRORED)
 {
 	m_ActLED.Blink (5);	// show we are alive
 }

--- a/addon/display/ssd1306device.cpp
+++ b/addon/display/ssd1306device.cpp
@@ -111,13 +111,15 @@ constexpr auto FontDouble = Font<FONT_SIZE, decltype(DoubleColumn)>(Font6x8, Dou
 
 
 CSSD1306Device::CSSD1306Device (unsigned nWidth, unsigned nHeight,
-				CI2CMaster *pI2CMaster, u8 nAddress)
+				CI2CMaster *pI2CMaster, u8 nAddress,
+			    bool rotated, bool mirrored)
 :	CCharDevice (SSD1306_COLUMNS, SSD1306_ROWS),
 	m_nWidth (nWidth),
 	m_nHeight (nHeight),
 	m_pI2CMaster (pI2CMaster),
 	m_nAddress (nAddress),
-
+	m_bRotated (rotated),
+	m_bMirrored (mirrored),
 	m_FrameBuffers{{0x40, {0}}, {0x40, {0}}},
 	m_nCurrentFrameBuffer(0)
 {
@@ -143,8 +145,8 @@ boolean CSSD1306Device::Initialize (void)
 	//            normal    inverted
 	// normal     A1 C8       A0 C0
 	// mirrored   A0 C8       A1 C0
-	const u8 nSegRemap        = 0xA1;
-	const u8 nCOMScanDir      = 0xC8;
+	const u8 nSegRemap        = (m_bRotated && !m_bMirrored) || (!m_bRotated && m_bMirrored) ? 0xA0 : 0xA1;
+	const u8 nCOMScanDir      = m_bRotated ? 0xC0 : 0xC8;
 
 	const u8 InitSequence[] =
 	{

--- a/addon/display/ssd1306device.h
+++ b/addon/display/ssd1306device.h
@@ -38,7 +38,8 @@ public:
 	/// \param pI2CMaster I2C master to be used
 	/// \param nAddress I2C slave address of the display controller
 	CSSD1306Device (unsigned nWidth, unsigned nHeight,
-					CI2CMaster *pI2CMaster, u8 nAddress);
+					CI2CMaster *pI2CMaster, u8 nAddress,
+				   bool rotated=false, bool mirrored=false);
 	~CSSD1306Device (void);
 
 	/// \return Operation successful?
@@ -67,6 +68,8 @@ private:
 	CI2CMaster *m_pI2CMaster;
 	u8 m_nAddress;
 	bool m_bBacklightEnabled;
+    bool m_bRotated;
+    bool m_bMirrored;
 
 	struct TFrameBufferUpdatePacket
 	{


### PR DESCRIPTION
Added options to the SSD1306 driver to support a rotated or mirrored display via the constructor on initialisation and updated the sample application to demonstrate its use.