### PR TITLE
Make KERNEL_STACK_SIZE configurable

### DIFF
--- a/include/circle/memorymap.h
+++ b/include/circle/memorymap.h
@@ -39,7 +39,6 @@
 
 #define PAGE_SIZE		4096				// page size used by us
 
-#define KERNEL_STACK_SIZE	0x20000				// all sizes must be a multiple of 16K
 #define EXCEPTION_STACK_SIZE	0x8000
 #define PAGE_TABLE1_SIZE	0x4000
 #define PAGE_RESERVE		(4 * MEGABYTE)

--- a/include/circle/memorymap64.h
+++ b/include/circle/memorymap64.h
@@ -41,7 +41,6 @@
 
 #define PAGE_SIZE		0x10000				// page size used by us
 
-#define KERNEL_STACK_SIZE	0x20000
 #define EXCEPTION_STACK_SIZE	0x8000
 #define PAGE_RESERVE		(16 * MEGABYTE)
 

--- a/include/circle/sysconfig.h
+++ b/include/circle/sysconfig.h
@@ -38,6 +38,13 @@
 #define KERNEL_MAX_SIZE		(2 * MEGABYTE)
 #endif
 
+// KERNEL_STACK_SIZE is the size of the stack set on startup for the
+// main thread.  This must be a multiple of 16 KByte.
+
+#ifndef KERNEL_STACK_SIZE
+#define KERNEL_STACK_SiZE	0x20000
+#endif
+
 // HEAP_DEFAULT_NEW defines the default heap to be used for the "new"
 // operator, if a memory type is not explicitly specified. Possible
 // values are HEAP_LOW (memory below 1 GByte), HEAP_HIGH (memory above


### PR DESCRIPTION
This is a proposal to make KERNEL_STACK_SIZE configurable via sysconfig.h or Config.mk, in parallel to KERNEL_MAX_SIZE.  It removes

#define KERNEL_STACK_SIZE 0x20000

from memorymap.h and memorymap64.h, and moves it instead to sysconfig.h, made conditional on the symbol not already being defined (so that it can be overridden).  I ran into this because I need a larger stack size than the default, and it's of course better not to have to directly edit the base code in my local repos clone.
