### PR TITLE
DrawImageRect uses display stride instead of image stride

### DIFF
--- a/lib/2dgraphics.cpp
+++ b/lib/2dgraphics.cpp
@@ -270,7 +270,7 @@ void C2DGraphics::DrawImageRect (unsigned nX, unsigned nY, unsigned nWidth, unsi
 	{
 		for(unsigned j=0; j<nWidth; j++)
 		{
-			m_Buffer[(nY + i) * m_nWidth + j + nX] = PixelBuffer[(nSourceY + i) * m_nWidth + j + nSourceX];
+			m_Buffer[(nY + i) * m_nWidth + j + nX] = PixelBuffer[(nSourceY + i) * nWidth + j + nSourceX];
 		}
 	}
 }


### PR DESCRIPTION
The current behavior copies pixels from the source image using the display stride, not the image stride. This causes the RPi to draw garbage on screen if the source image is not the same resolution as what is displayed on screen.

This is what is currently drawn on screen now
![Untitled-1](https://user-images.githubusercontent.com/15097070/234268712-74354af1-07dd-4526-8751-fb8ff8557b91.jpg)

This is what is expected to be drawn
![Untitled-2](https://user-images.githubusercontent.com/15097070/234268808-29116c0a-26b6-4e18-831e-b2607257ebe6.jpg)

