### PR TITLE
Added callback argument for keyboard and mouse raw mode callback handler

### DIFF
--- a/include/circle/input/mouse.h
+++ b/include/circle/input/mouse.h
@@ -28,6 +28,7 @@
 #define MOUSE_DISPLACEMENT_MIN	-127
 #define MOUSE_DISPLACEMENT_MAX	127
 
+typedef void TMouseStatusHandlerEx (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove, void* pArg);
 typedef void TMouseStatusHandler (unsigned nButtons, int nDisplacementX, int nDisplacementY, int nWheelMove);
 
 class CMouseDevice : public CDevice	/// Generic mouse interface device ("mouse1")
@@ -64,6 +65,7 @@ public:
 
 	/// \brief Register mouse status handler in raw mode
 	/// \param pStatusHandler Pointer to the mouse status handler
+	void RegisterStatusHandler (TMouseStatusHandlerEx *pStatusHandler, void* pArg);
 	void RegisterStatusHandler (TMouseStatusHandler *pStatusHandler);
 
 	/// \return Number of supported mouse buttons
@@ -79,7 +81,8 @@ public:
 private:
 	CMouseBehaviour m_Behaviour;
 
-	TMouseStatusHandler *m_pStatusHandler;
+	TMouseStatusHandlerEx *m_pStatusHandler;
+	void* m_pStatusHandlerArg;
 
 	unsigned m_nDeviceNumber;
 	static CNumberPool s_DeviceNumberPool;

--- a/include/circle/usb/usbkeyboard.h
+++ b/include/circle/usb/usbkeyboard.h
@@ -31,6 +31,8 @@
 // The raw handler is called when the keyboard sends a status report (on status change and/or continously).
 typedef void TKeyStatusHandlerRaw (unsigned char	ucModifiers,	// see usbhid.h
 				   const unsigned char	RawKeys[6]);	// key code or 0 in each byte
+typedef void TKeyStatusHandlerRawEx (unsigned char	ucModifiers,	// see usbhid.h
+				   const unsigned char	RawKeys[6], void* arg);	// key code or 0 in each byte
 
 class CUSBKeyboardDevice : public CUSBHIDDevice
 {
@@ -51,6 +53,8 @@ public:
 	u8 GetLEDStatus (void) const;	// returns USB LED status to be handed-over to SetLEDs()
 
 	// raw mode (if bMixedMode is FALSE, the cooked handlers are ignored)
+	void RegisterKeyStatusHandlerRaw (TKeyStatusHandlerRawEx *pKeyStatusHandlerRaw,
+					  boolean bMixedMode, void* pArg);
 	void RegisterKeyStatusHandlerRaw (TKeyStatusHandlerRaw *pKeyStatusHandlerRaw,
 					  boolean bMixedMode = FALSE);
 	void UnregisterKeyStatusHandlerRaw (void);
@@ -66,7 +70,8 @@ private:
 private:
 	CKeyboardBehaviour m_Behaviour;
 
-	TKeyStatusHandlerRaw *m_pKeyStatusHandlerRaw;
+	TKeyStatusHandlerRawEx *m_pKeyStatusHandlerRaw;
+	void* m_pKeyStatusHandlerRawArg;
 	boolean m_bMixedMode;
 
 	u8 m_LastReport[USBKEYB_REPORT_SIZE];


### PR DESCRIPTION
When using raw mode mouse and keyboard handlers there's no way to tell in the handler which device is invoking the callback.  This PR adds a "void* arg" callback argument that will be passed to the callback when invoked.

Implemented in a backwards compatible way so code using the old arg-less methods still compile and work as before.