### PR TITLE
Added CDevice::IOCtl method

### DIFF
--- a/include/circle/device.h
+++ b/include/circle/device.h
@@ -52,6 +52,13 @@ public:
 	/// \note Supported by block devices only
 	virtual u64 GetSize (void) const;
 
+    /// \param cmd The IOCtl command to invoke
+	/// \param data Depends on command, used to return command specific data
+	/// \return Zero on success, or error code on failure
+	/// \note Provides ability to invoke device specific I/O control comands
+	///       See FatFS `disk_ioctl` for how this might be used.
+	virtual int IOCtl (unsigned long cmd, void* data) { return -1; }; 
+
 	/// \return TRUE on successful device removal
 	virtual boolean RemoveDevice (void);
 


### PR DESCRIPTION
Added a IOCtl method to the CDevice class.  This completes the typical set of methods that a posix like device would normally support. 

While not actually used by circle , I'm using this on a "RamDisk" device in my project and map FatFS disk_ioctl calls to it.  

(I understand if you don't want to include this in circle, but it's just one virtual no-op method and by having it included in the base CDevice class it saves me having to implement my own separate and conflicting CDevice class. ).