### PR TITLE
Added SysConfig.h variable for name of "main()"

### DIFF
--- a/include/circle/sysconfig.h
+++ b/include/circle/sysconfig.h
@@ -417,6 +417,19 @@
 
 #endif
 
+
+// Sets the name of the "main()" entry point function that will be
+// called by circle after system initialization has completed.
+//
+// 	extern int MAINPROC (void);
+//
+// Can be used by wrapper libraries that need to inject their
+// own startup/shutdown code before calling their client's main().
+
+#ifndef MAINPROC
+#define MAINPROC main
+#endif
+
 ///////////////////////////////////////////////////////////////////////
 
 #include <circle/memorymap.h>

--- a/lib/sysinit.cpp
+++ b/lib/sysinit.cpp
@@ -251,8 +251,8 @@ void sysinit (void)
 		(**pFunc) ();
 	}
 
-	extern int main (void);
-	if (main () == EXIT_REBOOT)
+	extern int MAINPROC (void);
+	if (MAINPROC () == EXIT_REBOOT)
 	{
 		if (IsChainBootEnabled ())
 		{


### PR DESCRIPTION
This is a simple change to allow redefining the name of the "main()" proc.

Use case: I have an intermediate library that wraps circle and has its own startup/shutdown code.  This change enables circle to call my library's entry point (eg: -DMAINPROC=mylib_main) to do its own initialization before on-calling the application's "main()".

(I could require apps that use my library to have a different main proc name, but I like the idea of keeping this transparent and leaving it as "main()");