### PR TITLE
Update bootloader.txt to make bootloader64 if building for AArch64

### DIFF
--- a/doc/bootloader.txt
+++ b/doc/bootloader.txt
@@ -30,13 +30,17 @@ using the serial interface.
 4. The Circle project libraries used in your application have to be build
 manually using "./makeall" as described in the main README.md file.
 
-5. You have to prepare a SD card, which starts your Raspberry Pi in bootloader
-mode. Go to the boot/ subdirectory and enter:
+5. You have to prepare a SD card with a FAT partition, which starts your
+Raspberry Pi in bootloader mode. Go to the boot/ subdirectory and enter:
 
 	make all
 
-After completion copy the files from boot/ to the SD card (copy the file
-"config.txt" only for AArch64 operation), which must have a FAT partition.
+5b. If building for AArch64, then additionally enter:
+
+	make bootloader64
+
+After completion copy the files from boot/ to the SD card's FAT partition and in 
+the destination, rename config32.txt or config64.txt (for AArch64) to config.txt.
 Please note, that you have to repeat this step, if you change the parameter
 FLASHBAUD in Config.mk. The built bootloader is specific for this baud rate. Put
 the SD card into your Raspberry Pi, which is connected to your development


### PR DESCRIPTION
need to additionally run "make bootloader64" if want to run on AArch64 rpi4, because the "make all" command in the Makefile is only:

"all: firmware bootloader"

(Of course alternatively the Makefile could be changed to automatically detect whether "AARCH" from Config.mk is "32" or "64".)