### PR TITLE
Add CTimer::GetClockTicks64 function

### DIFF
--- a/include/circle/timer.h
+++ b/include/circle/timer.h
@@ -66,6 +66,9 @@ public:
 
 	/// \return Current clock ticks of an 1 MHz counter, may wrap
 	static unsigned GetClockTicks (void);
+
+	/// \return Current clock ticks of an 1 MHz counter (continuous)
+	static u64 GetClockTicks64 (void);
 #define CLOCKHZ	1000000
 
 	/// \return 1/HZ seconds since system boot, may wrap


### PR DESCRIPTION
This should support all options the same way `CTimer::GetClockTicks` does.
The changes are minimal, except for the physical counter part.

I hope that is okay :)
Also, thanks for the quick reply!

Closes #410 