### PR TITLE
Add support for XBox Series X controller

### DIFF
--- a/lib/usb/usbdevicefactory.cpp
+++ b/lib/usb/usbdevicefactory.cpp
@@ -124,7 +124,8 @@ CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pNam
 	else if (   pName->Compare ("ven45e-2d1") == 0		// XBox One Controller
 		 || pName->Compare ("ven45e-2dd") == 0		// XBox One Controller (FW 2015)
 		 || pName->Compare ("ven45e-2e3") == 0		// XBox One Elite Controller
-		 || pName->Compare ("ven45e-2ea") == 0)		// XBox One S Controller
+		 || pName->Compare ("ven45e-2ea") == 0		// XBox One S Controller
+		 || pName->Compare ("ven45e-b12") == 0)		// XBox Series X Controller
 	{
 		pResult = new CUSBGamePadXboxOneDevice (pParent);
 	}

--- a/lib/usb/usbgamepadxboxone.cpp
+++ b/lib/usb/usbgamepadxboxone.cpp
@@ -152,7 +152,9 @@ void CUSBGamePadXboxOneDevice::ReportHandler (const u8 *pReport, unsigned report
 
 	// Controller sends "heartbeat" packets periodically starting with
 	// 0x03, 0x20. We aren't interested in them.
-	if (m_pStatusHandler != nullptr && reportSize == 18 && pReport[0] == 0x20)
+	//
+	// XBox One controller has packet size 18, Series X controller has size 48
+	if (m_pStatusHandler != nullptr && (reportSize == 18 || reportSize == 48) && pReport[0] == 0x20)
 	{
 		DecodeReport (pReport);
 


### PR DESCRIPTION
The XBox One driver should support the XBox Series X controller `045e:0b12` (it supports it in xpad.c in Linux), but, because the packet size changed and circle hardcodes the packet size, a small change was required to support it.