### PR TITLE
Add ST7789 character device overlay

### DIFF
--- a/addon/display/Makefile
+++ b/addon/display/Makefile
@@ -4,7 +4,7 @@
 
 CIRCLEHOME = ../..
 
-OBJS	= hd44780device.o st7789display.o chardevice.o ssd1306device.o
+OBJS	= hd44780device.o st7789display.o chardevice.o ssd1306device.o st7789device.o
 
 libdisplay.a: $(OBJS)
 	@echo "  AR    $@"

--- a/addon/display/sample/st7789char/Makefile
+++ b/addon/display/sample/st7789char/Makefile
@@ -1,0 +1,17 @@
+#
+# Makefile
+#
+
+CIRCLEHOME = ../../../..
+
+OBJS	= main.o kernel.o
+
+LIBS	= $(CIRCLEHOME)/addon/display/libdisplay.a \
+	  $(CIRCLEHOME)/lib/usb/libusb.a \
+	  $(CIRCLEHOME)/lib/input/libinput.a \
+	  $(CIRCLEHOME)/lib/fs/libfs.a \
+	  $(CIRCLEHOME)/lib/libcircle.a
+
+include $(CIRCLEHOME)/Rules.mk
+
+-include $(DEPS)

--- a/addon/display/sample/st7789char/README
+++ b/addon/display/sample/st7789char/README
@@ -1,0 +1,37 @@
+README
+
+This sample demonstrates using the character driver for ST7789-based dot-matrix displays.
+You have to set your hardware configuration in the file kernel.cpp before build.
+The DC_PIN is required, the RESET_PIN and BACKLIGHT_PIN are optional and not
+provided by some displays. Please specify the GPIO chip number (not the header
+position) here or CST7789Display::None, if the pin is not connected.
+
+This relies on the st7789 display driver to function.
+
+The default display connection is as follows:
+
+Display		Raspberry Pi	Comment
+			GPIO
+
+SCL	<--	SCLK	11	SPI clock
+SDA	<--	MOSI	10	SPI data
+CS		not used	Chip select, e.g. GPIO8 (CS0) or GPIO7 (CS1)
+DC	<--		22	Data/Command selection
+RES	<--		23	Reset
+BLK		not used	Backlight, e.g. GPIO24
+VCC	<--	3.3V		may be 5V for some displays (be careful!)
+GND	<-->	GND
+
+An additional DOUT line is not used, if provided by the display. In the given
+configuration the SPI settings CPOL/CPHA are normally 1/0. If a chip select line
+is provided by your display, this may change to CPOL/CPHA 0/0. You can try this
+out, if the display does not work.
+
+There are two modes of the demo program. If you start it without an USB keyboard
+connected, it will display "No keyboard!" on the LCD display and will count the
+time from program start on.
+
+With an USB keyboard connected you can type on it and the typed characters will
+be echoed to the LCD display. You may have to set-up your keyboard map first,
+using the "keymap=" setting in cmdline.txt (see doc/cmdline.txt) to get
+reasonable results here.

--- a/addon/display/sample/st7789char/kernel.cpp
+++ b/addon/display/sample/st7789char/kernel.cpp
@@ -1,0 +1,204 @@
+//
+// kernel.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2024  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "kernel.h"
+#include <circle/usb/usbkeyboard.h>
+#include <circle/input/keyboardbuffer.h>
+#include <circle/time.h>
+#include <circle/string.h>
+#include <circle/util.h>
+#include <circle/machineinfo.h>
+
+#define SPI_MASTER_DEVICE	0		// 0, 4, 5, 6 on Raspberry Pi 4; 0 otherwise
+#define SPI_CLOCK_SPEED		15000000	// Hz
+#define SPI_CPOL		1		// try 0, if it does not work
+#define SPI_CPHA		0		// try 1, if it does not work
+#define SPI_CHIP_SELECT		0		// 0 or 1; don't care, if not connected
+
+#define WIDTH			240		// display width in pixels
+#define HEIGHT			240		// display height in pixels
+#define DC_PIN			22
+#define RESET_PIN		23		// or CST7789Display::None
+#define BACKLIGHT_PIN	CST7789Display::None
+
+#define COLS  15	// Max 40
+#define ROWS  4		// Max 4
+#define ROT   0 	// 0,90,180,270
+#define WIDECHARS	true	// Set to false for thin characters
+
+#define MY_COLOR		ST7789_COLOR (31, 31, 15)	// any color
+
+static const char FromKernel[] = "kernel";
+
+CKernel::CKernel (void)
+:	m_Screen (m_Options.GetWidth (), m_Options.GetHeight ()),
+	m_Timer (&m_Interrupt),
+	m_Logger (m_Options.GetLogLevel (), &m_Timer),
+	m_USBHCI (&m_Interrupt, &m_Timer),
+	m_SPIMaster (SPI_CLOCK_SPEED, SPI_CPOL, SPI_CPHA, SPI_MASTER_DEVICE),
+	m_Display (&m_SPIMaster, DC_PIN, RESET_PIN, BACKLIGHT_PIN, WIDTH, HEIGHT,
+		   SPI_CPOL, SPI_CPHA, SPI_CLOCK_SPEED, SPI_CHIP_SELECT),
+	m_pLCD (nullptr)
+{
+	m_ActLED.Blink (5);	// show we are alive
+}
+
+CKernel::~CKernel (void)
+{
+}
+
+boolean CKernel::Initialize (void)
+{
+	boolean bOK = TRUE;
+
+	if (bOK)
+	{
+		bOK = m_Screen.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_Serial.Initialize (115200);
+	}
+
+	if (bOK)
+	{
+		CDevice *pTarget = m_DeviceNameService.GetDevice (m_Options.GetLogDevice (), FALSE);
+		if (pTarget == 0)
+		{
+			pTarget = &m_Screen;
+		}
+
+		bOK = m_Logger.Initialize (pTarget);
+	}
+
+	if (bOK)
+	{
+		bOK = m_Interrupt.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_Timer.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_USBHCI.Initialize ();
+	}
+	
+	if (bOK)
+	{
+		bOK = m_SPIMaster.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_Display.Initialize ();
+		m_Display.SetRotation(ROT);
+	}
+
+	if (bOK)
+	{
+		// Cannot instantiate the ST7789 device until the disply has been initialised
+		m_pLCD = new CST7789Device (&m_SPIMaster, &m_Display, COLS, ROWS, WIDECHARS);
+		assert (m_pLCD);
+		bOK = m_pLCD->Initialize ();
+	}
+
+	return bOK;
+}
+
+TShutdownMode CKernel::Run (void)
+{
+	m_Logger.Write (FromKernel, LogNotice, "Compile time: " __DATE__ " " __TIME__);
+
+	LCDWrite ("01234567890123456789");
+	LCDWrite (">>>>>>>>>>>>>>>>>>>");
+
+	unsigned nTime = 10 + m_Timer.GetTime ();
+	while (nTime > m_Timer.GetTime ())
+	{
+		// just wait a few seconds
+	}
+	
+	LCDWrite ("\E[H\E[J"); // Reset cursor and clear display
+
+	CUSBKeyboardDevice *pKeyboard =
+		(CUSBKeyboardDevice *) m_DeviceNameService.GetDevice ("ukbd1", FALSE);
+	if (pKeyboard == 0)
+	{
+		m_Logger.Write (FromKernel, LogError, "Keyboard not found");
+
+		TimeDemo ();
+
+		return ShutdownHalt;
+	}
+
+	CKeyboardBuffer Keyboard (pKeyboard);
+
+	m_Logger.Write (FromKernel, LogNotice, "Just type something!");
+	LCDWrite ("Just type!\n");
+
+	for (unsigned nCount = 0; 1; nCount++)
+	{
+		char Buffer[10];
+		int nResult = Keyboard.Read (Buffer, sizeof Buffer);
+		if (nResult > 0)
+		{
+			m_pLCD->Write (Buffer, nResult);
+		}
+
+		m_Screen.Rotor (0, nCount);
+	}
+
+	return ShutdownHalt;
+}
+
+void CKernel::TimeDemo (void)
+{
+	LCDWrite ("\x1B[?25l");		// cursor off
+	LCDWrite ("------------\n");
+	LCDWrite ("No keyboard!\n");
+
+	unsigned nTime = m_Timer.GetTime ();
+	while (1)
+	{
+		while (nTime == m_Timer.GetTime ())
+		{
+			// just wait a second
+		}
+
+		nTime = m_Timer.GetTime ();
+
+		CTime Time;
+		Time.Set (nTime);
+
+		CString String;
+		String.Format ("\r%02u:%02u:%02u",
+			Time.GetHours (), Time.GetMinutes (), Time.GetSeconds ());
+
+		LCDWrite ((const char *) String);
+	}
+}
+
+void CKernel::LCDWrite (const char *pString)
+{
+	m_pLCD->Write (pString, strlen (pString));
+}

--- a/addon/display/sample/st7789char/kernel.h
+++ b/addon/display/sample/st7789char/kernel.h
@@ -1,0 +1,77 @@
+//
+// kernel.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2024  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _kernel_h
+#define _kernel_h
+
+#include <circle/actled.h>
+#include <circle/koptions.h>
+#include <circle/devicenameservice.h>
+#include <circle/screen.h>
+#include <circle/serial.h>
+#include <circle/exceptionhandler.h>
+#include <circle/interrupt.h>
+#include <circle/timer.h>
+#include <circle/logger.h>
+#include <circle/usb/usbhcidevice.h>
+#include <circle/spimaster.h>
+#include <circle/types.h>
+#include <display/st7789display.h>
+#include <display/st7789device.h>
+
+enum TShutdownMode
+{
+	ShutdownNone,
+	ShutdownHalt,
+	ShutdownReboot
+};
+
+class CKernel
+{
+public:
+	CKernel (void);
+	~CKernel (void);
+
+	boolean Initialize (void);
+
+	TShutdownMode Run (void);
+	
+private:
+	void TimeDemo (void);
+
+	void LCDWrite (const char *pString);
+
+private:
+	// do not change this order
+	CActLED			m_ActLED;
+	CKernelOptions		m_Options;
+	CDeviceNameService	m_DeviceNameService;
+	CScreenDevice		m_Screen;
+	CSerialDevice		m_Serial;
+	CExceptionHandler	m_ExceptionHandler;
+	CInterruptSystem	m_Interrupt;
+	CTimer			m_Timer;
+	CLogger			m_Logger;
+	CUSBHCIDevice		m_USBHCI;
+	CSPIMaster		m_SPIMaster;
+	CST7789Display		m_Display;
+	CST7789Device		*m_pLCD;
+};
+
+#endif

--- a/addon/display/sample/st7789char/main.cpp
+++ b/addon/display/sample/st7789char/main.cpp
@@ -1,0 +1,47 @@
+//
+// main.c
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014  R. Stange <rsta2@o2online.de>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "kernel.h"
+#include <circle/startup.h>
+
+int main (void)
+{
+	// cannot return here because some destructors used in CKernel are not implemented
+
+	CKernel Kernel;
+	if (!Kernel.Initialize ())
+	{
+		halt ();
+		return EXIT_HALT;
+	}
+	
+	TShutdownMode ShutdownMode = Kernel.Run ();
+
+	switch (ShutdownMode)
+	{
+	case ShutdownReboot:
+		reboot ();
+		return EXIT_REBOOT;
+
+	case ShutdownHalt:
+	default:
+		halt ();
+		return EXIT_HALT;
+	}
+}

--- a/addon/display/st7789device.cpp
+++ b/addon/display/st7789device.cpp
@@ -1,0 +1,70 @@
+//
+// st7789device.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2018-2022  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "st7789device.h"
+#include <circle/timer.h>
+#include <assert.h>
+
+CST7789Device::CST7789Device (CSPIMaster *pSPIMaster, CST7789Display *pST7789Display,
+		unsigned nColumns, unsigned nRows,
+		boolean bBlockCursor)
+:	CCharDevice (nColumns, nRows),
+	m_pSPIMaster (pSPIMaster),
+	m_pST7789Display (pST7789Display),
+	m_bBlockCursor (bBlockCursor)
+{
+}
+
+CST7789Device::~CST7789Device (void)
+{
+}
+
+boolean CST7789Device::Initialize (void)
+{
+	return CCharDevice::Initialize();
+}
+
+void CST7789Device::DevClearCursor (void)
+{
+}
+
+void CST7789Device::DevSetCursorMode (boolean bVisible)
+{
+}
+
+void CST7789Device::DevSetChar (unsigned nPosX, unsigned nPosY, char chChar)
+{
+}
+
+void CST7789Device::DevSetCursor (unsigned nCursorX, unsigned nCursorY)
+{
+}
+
+void CST7789Device::DevUpdateDisplay (void)
+{
+}
+
+void CST7789Device::DefineCharFont (char chChar, const u8 FontData[8])
+{
+}
+
+void CST7789Device::WriteByte (u8 nData, int mode)
+{
+}
+

--- a/addon/display/st7789device.cpp
+++ b/addon/display/st7789device.cpp
@@ -2,7 +2,7 @@
 // st7789device.cpp
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2018-2022  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2018-2024  R. Stange <rsta2@o2online.de>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -19,14 +19,19 @@
 //
 #include "st7789device.h"
 #include <circle/timer.h>
+#include <circle/chargenerator.h>
 #include <assert.h>
+#include <stdio.h>
 
 CST7789Device::CST7789Device (CSPIMaster *pSPIMaster, CST7789Display *pST7789Display,
-		unsigned nColumns, unsigned nRows,
+		unsigned nColumns, unsigned nRows, bool bDoubleWidth,
 		boolean bBlockCursor)
 :	CCharDevice (nColumns, nRows),
 	m_pSPIMaster (pSPIMaster),
 	m_pST7789Display (pST7789Display),
+	m_nColumns (nColumns),
+	m_nRows (nRows),
+	m_bDoubleWidth (bDoubleWidth),
 	m_bBlockCursor (bBlockCursor)
 {
 }
@@ -37,11 +42,41 @@ CST7789Device::~CST7789Device (void)
 
 boolean CST7789Device::Initialize (void)
 {
+	// ST7789 display assumed to already be initialised prior to
+	// initialising the character device, so nothing more to be
+	// done here other than checking the dimensions are sensible...
+	
+	unsigned w = m_pST7789Display->GetWidth();
+	unsigned h = m_pST7789Display->GetHeight();
+	
+	// st7789display uses the chargenerator, so check some properties here.
+	// NB: By default it uses width/height x 2, but that can be changed
+	//     for the width if required.
+	CCharGenerator cg;
+	m_nCharW = cg.GetCharWidth() * (m_bDoubleWidth ? 2 : 1);
+	m_nCharH = cg.GetCharHeight() * 2;	
+
+	if (m_nColumns * m_nCharW > w)
+	{
+		// Limit number of columns to width of screen
+		m_nColumns = w / m_nCharW;
+	}
+	if (m_nRows * m_nCharH > h)
+	{
+		// Limit number of rows to height of screen
+		m_nRows = h / m_nCharH;
+	}
+	
+	m_pST7789Display->Clear(ST7789_BLACK_COLOR);
+	m_pST7789Display->On();
+
 	return CCharDevice::Initialize();
 }
 
 void CST7789Device::DevClearCursor (void)
 {
+	// Just clear the display
+	m_pST7789Display->Clear(ST7789_BLACK_COLOR);
 }
 
 void CST7789Device::DevSetCursorMode (boolean bVisible)
@@ -50,6 +85,21 @@ void CST7789Device::DevSetCursorMode (boolean bVisible)
 
 void CST7789Device::DevSetChar (unsigned nPosX, unsigned nPosY, char chChar)
 {
+	char s[2];
+	s[0] = chChar;
+	s[1] = '\0';
+
+	if ((nPosX >= m_nColumns) || (nPosY >= m_nRows))
+	{
+		// Off the display so quit
+		return;
+	}
+
+	// Convert from cursor coordinates to pixel coordinates
+	unsigned nXC = nPosX * m_nCharW;
+	unsigned nYC = nPosY * m_nCharH;
+
+	m_pST7789Display->DrawText(nXC, nYC, s, ST7789_WHITE_COLOR, ST7789_BLACK_COLOR, m_bDoubleWidth);
 }
 
 void CST7789Device::DevSetCursor (unsigned nCursorX, unsigned nCursorY)
@@ -59,12 +109,3 @@ void CST7789Device::DevSetCursor (unsigned nCursorX, unsigned nCursorY)
 void CST7789Device::DevUpdateDisplay (void)
 {
 }
-
-void CST7789Device::DefineCharFont (char chChar, const u8 FontData[8])
-{
-}
-
-void CST7789Device::WriteByte (u8 nData, int mode)
-{
-}
-

--- a/addon/display/st7789device.h
+++ b/addon/display/st7789device.h
@@ -2,7 +2,7 @@
 // st7789device.h
 //
 // Circle - A C++ bare metal environment for Raspberry Pi
-// Copyright (C) 2018-2022  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2018-2024  R. Stange <rsta2@o2online.de>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -36,15 +36,13 @@ public:
 	/// \param nRows    Display size in number of rows (max. 4)
 	/// \param bBlockCursor Use blinking block cursor instead of underline cursor
 	CST7789Device (CSPIMaster *pSPIMaster, CST7789Display *pST7789Display,
-		unsigned nColumns, unsigned nRows,
+		unsigned nColumns, unsigned nRows, bool bDoubleWidth = TRUE,
 		boolean bBlockCursor = FALSE);
 
 	~CST7789Device (void);
 
 	/// \return Operation successful?
 	boolean Initialize (void);
-
-	void DefineCharFont (char chChar, const u8 FontData[8]);
 
 private:
 	void DevClearCursor (void) override;
@@ -53,11 +51,15 @@ private:
 	void DevSetChar (unsigned nPosX, unsigned nPosY, char chChar) override;
 	void DevUpdateDisplay (void) override;
 
-	void WriteByte (u8 nData, int mode);
-
 private:
 	CSPIMaster		*m_pSPIMaster;
 	CST7789Display	*m_pST7789Display;
+
+	unsigned m_nColumns;
+	unsigned m_nRows;
+	unsigned m_nCharW;
+	unsigned m_nCharH;
+	bool     m_bDoubleWidth;
 
 	boolean m_bBlockCursor;
 };

--- a/addon/display/st7789device.h
+++ b/addon/display/st7789device.h
@@ -1,0 +1,65 @@
+//
+// st7789device.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2018-2022  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _display_st7789device_h
+#define _display_st7789device_h
+
+#include <circle/device.h>
+#include <circle/gpiopin.h>
+#include <circle/spinlock.h>
+#include <circle/types.h>
+#include "chardevice.h"
+#include "st7789display.h"
+
+class CST7789Device : public CCharDevice	/// LCD dot-matrix display driver (using ST7789 controller)
+{
+public:
+	/// \param pSPIMaster
+	/// \param pST7789Display
+	/// \param nColumns Display size in number of columns (max. 40)
+	/// \param nRows    Display size in number of rows (max. 4)
+	/// \param bBlockCursor Use blinking block cursor instead of underline cursor
+	CST7789Device (CSPIMaster *pSPIMaster, CST7789Display *pST7789Display,
+		unsigned nColumns, unsigned nRows,
+		boolean bBlockCursor = FALSE);
+
+	~CST7789Device (void);
+
+	/// \return Operation successful?
+	boolean Initialize (void);
+
+	void DefineCharFont (char chChar, const u8 FontData[8]);
+
+private:
+	void DevClearCursor (void) override;
+	void DevSetCursor (unsigned nCursorX, unsigned nCursorY) override;
+	void DevSetCursorMode (boolean bVisible) override;
+	void DevSetChar (unsigned nPosX, unsigned nPosY, char chChar) override;
+	void DevUpdateDisplay (void) override;
+
+	void WriteByte (u8 nData, int mode);
+
+private:
+	CSPIMaster		*m_pSPIMaster;
+	CST7789Display	*m_pST7789Display;
+
+	boolean m_bBlockCursor;
+};
+
+#endif

--- a/addon/display/st7789display.h
+++ b/addon/display/st7789display.h
@@ -70,6 +70,10 @@ public:
 	/// \return Operation successful?
 	boolean Initialize (void);
 
+	/// \brief Set the global rotation of the display
+	/// \param nRot (0, 90, 180, 270)
+	void SetRotation (unsigned nRot);
+
 	/// \brief Set display on
 	void On (void);
 	/// \brief Set display off
@@ -91,8 +95,10 @@ public:
 	/// \param pString 0-terminated string of printable characters
 	/// \param Color RGB565 foreground color with swapped bytes (see: ST7789_COLOR())
 	/// \param BgColor RGB565 background color with swapped bytes (see: ST7789_COLOR())
+	/// \param bDoubleWidth default TRUE for thicker characters on screen
 	void DrawText (unsigned nPosX, unsigned nPosY, const char *pString,
-		       TST7789Color Color, TST7789Color BgColor = ST7789_BLACK_COLOR);
+		       TST7789Color Color, TST7789Color BgColor = ST7789_BLACK_COLOR,
+				bool bDoubleWidth = true);
 
 private:
 	void SetWindow (unsigned x0, unsigned y0, unsigned x1, unsigned y1);
@@ -103,6 +109,9 @@ private:
 	void Data (u8 uchByte)		{ SendByte (uchByte, TRUE); }
 
 	void SendData (const void *pData, size_t nLength);
+	
+	unsigned RotX (unsigned x, unsigned y);
+	unsigned RotY (unsigned x, unsigned y);
 
 private:
 	CSPIMaster *m_pSPIMaster;
@@ -114,6 +123,7 @@ private:
 	unsigned m_CPHA;
 	unsigned m_nClockSpeed;
 	unsigned m_nChipSelect;
+	unsigned m_nRotation;
 
 	CGPIOPin m_DCPin;
 	CGPIOPin m_ResetPin;


### PR DESCRIPTION
This is a relatively shallow overlay layer using the existing addon/display/st7789 graphics driver to provide the same character/console interface as the ssd1306 and hd44780 displays.

To achieve this it has had to add an option for rotation and setting the width of characters in the main ST7789 display code too. 
 There is also a new sample application showing how it can be used.

If this is not wanted within circle itself, then I'll add it into MiniDexed directly.  Ultimately we want to support ST7789 displays in MiniDexed and this seemed like the simplest way to do it.

Note: I've set the sample application to use the same hardware configuration as the original ST7789 sample application, but this is untested as it isn't the hardware I have.

I've tested it with a Pimoroni Pirate Audio add-on with built-in ST7789 display.

Many Thanks,
Kevin
