### PR TITLE
Fix for character handling rotationfor asymetric displays

### DIFF
--- a/addon/display/sample/st7789char/kernel.cpp
+++ b/addon/display/sample/st7789char/kernel.cpp
@@ -40,7 +40,8 @@
 #define COLS  15	// Max 40
 #define ROWS  4		// Max 4
 #define ROT   0 	// 0,90,180,270
-#define WIDECHARS	true	// Set to false for thin characters
+#define WIDECHARS	TRUE	// Set to false for thin characters
+#define TALLCHARS	TRUE	// Set to false for short characters
 
 #define MY_COLOR		ST7789_COLOR (31, 31, 15)	// any color
 
@@ -117,7 +118,7 @@ boolean CKernel::Initialize (void)
 	if (bOK)
 	{
 		// Cannot instantiate the ST7789 device until the disply has been initialised
-		m_pLCD = new CST7789Device (&m_SPIMaster, &m_Display, COLS, ROWS, WIDECHARS);
+		m_pLCD = new CST7789Device (&m_SPIMaster, &m_Display, COLS, ROWS, WIDECHARS, TALLCHARS);
 		assert (m_pLCD);
 		bOK = m_pLCD->Initialize ();
 	}

--- a/addon/display/st7789device.cpp
+++ b/addon/display/st7789device.cpp
@@ -45,8 +45,14 @@ boolean CST7789Device::Initialize (void)
 	// initialising the character device, so nothing more to be
 	// done here other than checking the dimensions are sensible...
 	
+	unsigned r = m_pST7789Display->GetRotation();
 	unsigned w = m_pST7789Display->GetWidth();
-	unsigned h = m_pST7789Display->GetHeight();
+	unsigned h = m_pST7789Display->GetHeight();	
+	if (r==90 || r==270) {
+		// Swap w/h if rotated
+		w = m_pST7789Display->GetHeight();
+		h = m_pST7789Display->GetWidth();
+	}
 	
 	// st7789display uses the chargenerator, so check some properties here.
 	// NB: By default it uses width/height x 2, but that can be changed

--- a/addon/display/st7789device.cpp
+++ b/addon/display/st7789device.cpp
@@ -23,7 +23,7 @@
 #include <assert.h>
 
 CST7789Device::CST7789Device (CSPIMaster *pSPIMaster, CST7789Display *pST7789Display,
-		unsigned nColumns, unsigned nRows, bool bDoubleWidth,
+		unsigned nColumns, unsigned nRows, bool bDoubleWidth, bool bDoubleHeight,
 		boolean bBlockCursor)
 :	CCharDevice (nColumns, nRows),
 	m_pSPIMaster (pSPIMaster),
@@ -31,6 +31,7 @@ CST7789Device::CST7789Device (CSPIMaster *pSPIMaster, CST7789Display *pST7789Dis
 	m_nColumns (nColumns),
 	m_nRows (nRows),
 	m_bDoubleWidth (bDoubleWidth),
+	m_bDoubleHeight (bDoubleHeight),
 	m_bBlockCursor (bBlockCursor)
 {
 }
@@ -59,7 +60,7 @@ boolean CST7789Device::Initialize (void)
 	//     for the width if required.
 	CCharGenerator cg;
 	m_nCharW = cg.GetCharWidth() * (m_bDoubleWidth ? 2 : 1);
-	m_nCharH = cg.GetCharHeight() * 2;	
+	m_nCharH = cg.GetCharHeight() * (m_bDoubleHeight ? 2 : 1);
 
 	if (m_nColumns * m_nCharW > w)
 	{
@@ -104,7 +105,7 @@ void CST7789Device::DevSetChar (unsigned nPosX, unsigned nPosY, char chChar)
 	unsigned nXC = nPosX * m_nCharW;
 	unsigned nYC = nPosY * m_nCharH;
 
-	m_pST7789Display->DrawText(nXC, nYC, s, ST7789_WHITE_COLOR, ST7789_BLACK_COLOR, m_bDoubleWidth);
+	m_pST7789Display->DrawText(nXC, nYC, s, ST7789_WHITE_COLOR, ST7789_BLACK_COLOR, m_bDoubleWidth, m_bDoubleHeight);
 }
 
 void CST7789Device::DevSetCursor (unsigned nCursorX, unsigned nCursorY)

--- a/addon/display/st7789device.h
+++ b/addon/display/st7789device.h
@@ -36,7 +36,7 @@ public:
 	/// \param nRows    Display size in number of rows (max. 4)
 	/// \param bBlockCursor Use blinking block cursor instead of underline cursor
 	CST7789Device (CSPIMaster *pSPIMaster, CST7789Display *pST7789Display,
-		unsigned nColumns, unsigned nRows, bool bDoubleWidth = TRUE,
+		unsigned nColumns, unsigned nRows, bool bDoubleWidth = TRUE, bool bDoubleHeight = TRUE,
 		boolean bBlockCursor = FALSE);
 
 	~CST7789Device (void);
@@ -60,6 +60,7 @@ private:
 	unsigned m_nCharW;
 	unsigned m_nCharH;
 	bool     m_bDoubleWidth;
+	bool     m_bDoubleHeight;
 
 	boolean m_bBlockCursor;
 };

--- a/addon/display/st7789display.cpp
+++ b/addon/display/st7789display.cpp
@@ -320,13 +320,14 @@ void CST7789Display::SetPixel (unsigned nPosX, unsigned nPosY, TST7789Color Colo
 }
 
 void CST7789Display::DrawText (unsigned nPosX, unsigned nPosY, const char *pString,
-			       TST7789Color Color, TST7789Color BgColor, bool bDoubleWidth)
+			       TST7789Color Color, TST7789Color BgColor, bool bDoubleWidth, bool bDoubleHeight)
 {
 	assert (pString != 0);
 
 	unsigned nWidthScaler = (bDoubleWidth ? 2 : 1);
+	unsigned nHeightScaler = (bDoubleHeight ? 2 : 1);
 	unsigned nCharWidth = m_CharGen.GetCharWidth () * nWidthScaler;
-	unsigned nCharHeight = m_CharGen.GetCharHeight () * 2;
+	unsigned nCharHeight = m_CharGen.GetCharHeight () * nHeightScaler;
 
 	TST7789Color Buffer[nCharHeight * nCharWidth];
 
@@ -337,7 +338,7 @@ void CST7789Display::DrawText (unsigned nPosX, unsigned nPosY, const char *pStri
 		{
 			for (unsigned x = 0; x < nCharWidth; x++)
 			{
-				TST7789Color pix = m_CharGen.GetPixel (chChar, x/nWidthScaler, y/2)
+				TST7789Color pix = m_CharGen.GetPixel (chChar, x/nWidthScaler, y/nHeightScaler)
 											? Color : BgColor;
 				// Rotation determines order of bytes in the buffer
 				switch (m_nRotation)

--- a/addon/display/st7789display.h
+++ b/addon/display/st7789display.h
@@ -100,7 +100,7 @@ public:
 	/// \param bDoubleWidth default TRUE for thicker characters on screen
 	void DrawText (unsigned nPosX, unsigned nPosY, const char *pString,
 		       TST7789Color Color, TST7789Color BgColor = ST7789_BLACK_COLOR,
-				bool bDoubleWidth = true);
+			bool bDoubleWidth = TRUE, bool bDoubleHeight = TRUE);
 
 private:
 	void SetWindow (unsigned x0, unsigned y0, unsigned x1, unsigned y1);

--- a/addon/display/st7789display.h
+++ b/addon/display/st7789display.h
@@ -73,6 +73,8 @@ public:
 	/// \brief Set the global rotation of the display
 	/// \param nRot (0, 90, 180, 270)
 	void SetRotation (unsigned nRot);
+	/// \return Rotation in degrees (0,90,180,270)
+	unsigned GetRotation (void) const	{ return m_nRotation; }
 
 	/// \brief Set display on
 	void On (void);


### PR DESCRIPTION
My apologies Rene!  There was a bug in the character handling for rotations which I'd missed as my displays were all square!  Hopefully this sorts that out.

Sorry about that! I think that is ok now... but I don't have a wide range of displays to test it on unfortunately.  Hopefully once in the branch a few others might be able to give it a go.

Many Thanks,
Kevin
