### PR TITLE
Fixed LVGL Makefile.

### DIFF
--- a/addon/lvgl/Makefile
+++ b/addon/lvgl/Makefile
@@ -3,11 +3,13 @@
 #
 
 CIRCLEHOME = ../..
+LVGL_DIR = lvgl
 
-LVGL_DIR = .
-LVGL_DIR_NAME = lvgl
+ifeq (,$(wildcard $(LVGL_DIR)/lvgl.mk))
+    $(error LVGL submodule not checked out!)
+endif
 
-include $(LVGL_DIR)/lvgl/lvgl.mk
+include $(LVGL_DIR)/lvgl.mk
 
 OBJS = lvgl.o $(CSRCS:.c=.o)
 


### PR DESCRIPTION
LVGL would not build as pulled; the reference to `lvgl.h` was nested one level too deep:

```
make: *** No rule to make target 'lvgl/lvgl/lvgl.h', needed by 'lvgl.o'.  Stop.
```

I fixed that, tidied up a bit, and added a check to warn if the LVGL submodule is missing. 