### PR TITLE
Fix backlight issue for older RPi 7" Touchscreen Display

### DIFF
--- a/doc/cmdline.txt
+++ b/doc/cmdline.txt
@@ -70,3 +70,6 @@ gpiofanpin=2			GPIO pin number (SoC number, not header position) to which the
 touchscreen=140,3960,340,3920	Set calibration coordinates for USB touchscreens
 				(minimum x, maximum x, minimum y, maximum y)
 				Use tools/touchscreen-calibrator to determine the values!
+
+backlight=150			Set an initial backlight value for the Raspberry Pi Touchscreen.
+				This should only be necessary for the older control board (v1.0).

--- a/doc/issues.txt
+++ b/doc/issues.txt
@@ -51,6 +51,10 @@ Known issues of Circle are:
 * The WLAN connection is delicate on the Raspberry Pi 5, when a HDMI display is
   used at the same time.
 
+* The Official Touchscreen may not initialize successfully. If you have an old
+  controller (v1.0), the backlight is not set by the firmware on startup. To
+  resolve this set the option backlight=150 in the file cmdline.txt. See the
+  file doc/cmdline.txt for details.
 
 You can see or report further issues here:
 

--- a/include/circle/koptions.h
+++ b/include/circle/koptions.h
@@ -54,6 +54,8 @@ public:
 
 	const unsigned *GetTouchScreen (void) const;	// returns 4 values (nullptr if unset)
 
+	unsigned GetBacklight (void) const;		// returns 0, if not defined
+
 	// for application-defined options:
 	const char *GetAppOptionString (const char *pOption, const char *pDefault = nullptr) const;
 	unsigned GetAppOptionDecimal (const char *pOption, unsigned nDefault = -1) const;
@@ -107,6 +109,8 @@ private:
 	};
 
 	TAppOption *m_pAppOptionList;
+
+        unsigned m_nBacklight;
 
 	static CKernelOptions *s_pThis;
 };

--- a/lib/bcmframebuffer.cpp
+++ b/lib/bcmframebuffer.cpp
@@ -19,6 +19,7 @@
 //
 #include <circle/bcmframebuffer.h>
 #include <circle/util.h>
+#include <circle/koptions.h>
 
 const TBcmFrameBufferInitTags CBcmFrameBuffer::s_InitTags =
 {
@@ -167,7 +168,23 @@ boolean CBcmFrameBuffer::Initialize (void)
 	m_nBufferSize = m_InitTags.AllocateBuffer.nBufferSize;
 	m_nPitch      = m_InitTags.GetPitch.nValue;
 
-	return UpdatePalette ();
+	boolean bOK = UpdatePalette();
+	if (bOK)
+	{
+		unsigned nBrightness = 0;
+
+		CKernelOptions* pOptions = CKernelOptions::Get();
+		if (pOptions)
+		{
+			nBrightness = pOptions->GetBacklight();
+		}
+
+		if (nBrightness != 0)
+		{
+			bOK = SetBacklightBrightness (nBrightness);
+		}
+	}
+	return bOK;
 }
 
 unsigned CBcmFrameBuffer::GetWidth (void) const

--- a/lib/koptions.cpp
+++ b/lib/koptions.cpp
@@ -39,7 +39,8 @@ CKernelOptions::CKernelOptions (void)
 	m_nSoCMaxTemp (60),
 	m_nGPIOFanPin (0),
 	m_bTouchScreenValid (FALSE),
-	m_pAppOptionList (nullptr)
+	m_pAppOptionList (nullptr),
+        m_nBacklight (0)
 {
 	strcpy (m_LogDevice, "tty1");
 	strcpy (m_KeyMap, DEFAULT_KEYMAP);
@@ -181,6 +182,15 @@ CKernelOptions::CKernelOptions (void)
 		{
 			m_bTouchScreenValid = GetDecimals (pValue, m_TouchScreen, 4);
 		}
+		else if (strcmp (pOption, "backlight") == 0)
+		{
+			unsigned nValue;
+			if (   (nValue = GetDecimal (pValue)) != INVALID_VALUE
+			    && 1 <= nValue && nValue <= 255)
+			{
+				m_nBacklight = nValue;
+			}
+		}
 		else
 		{
 			TAppOption *pAppOption = new TAppOption;
@@ -290,6 +300,11 @@ unsigned CKernelOptions::GetGPIOFanPin (void) const
 const unsigned *CKernelOptions::GetTouchScreen (void) const
 {
 	return m_bTouchScreenValid ? m_TouchScreen : nullptr;
+}
+
+unsigned CKernelOptions::GetBacklight (void) const
+{
+	return m_nBacklight;
 }
 
 const char *CKernelOptions::GetAppOptionString (const char *pOption, const char *pDefault) const


### PR DESCRIPTION
Older RPi 7" Touchscreen Display controller board (revision 1.0) does not seem to correctly set the backlight when starting.
This change adds 'backlight=' as a possible entry in cmdline.txt. If a value between 1 and 255 (inclusive) is supplied, this value is used to set the backlight when the BCM framebuffer is initialised. 