### PR TITLE
Add USB RTL8153 support

### DIFF
--- a/boot/.gitignore
+++ b/boot/.gitignore
@@ -4,3 +4,4 @@ LICENCE.broadcom
 start*.elf
 COPYING.linux
 *.dtb
+*.dtbo

--- a/lib/usb/usbdevice.cpp
+++ b/lib/usb/usbdevice.cpp
@@ -267,7 +267,9 @@ boolean CUSBDevice::Initialize (void)
 	if (   (   m_pDeviceDesc->idVendor  == 0x0525	// NetChip
 	        && m_pDeviceDesc->idProduct == 0xA4A2)	// Ethernet/RNDIS Gadget (QEMU)
 	    || (   m_pDeviceDesc->idVendor  == 0x0BDA	// Realtek
-	        && m_pDeviceDesc->idProduct == 0x8152))	// RTL8152
+	        && m_pDeviceDesc->idProduct == 0x8152)	// RTL8152
+	    || (   m_pDeviceDesc->idVendor  == 0x0BDA	// Realtek
+	        && m_pDeviceDesc->idProduct == 0x8153))	// RTL8153
 	{
 		ucConfigIndex++;
 	}


### PR DESCRIPTION
Specify the VID/PID for RTL8153 adaptors. Supports USB networking.