### PR TITLE
FIXED: configure: compatibility with macOS

### DIFF
--- a/configure
+++ b/configure
@@ -32,15 +32,6 @@ function usage()
 cd "${BASH_SOURCE%/*}" || exit 1
 TOPDIR="$PWD"
 
-TEMP=$(getopt -o r:p:d:fh \
-	--long raspberrypi:,prefix:,multicore,realtime,keymap:,qemu,define:,c++17,force,help \
-	-n 'configure' -- "$@")
-
-if [ $? != 0 ] ; then usage; exit 1 ; fi
-
-# Note the quotes around `$TEMP': they are essential!
-eval set -- "$TEMP"
-
 RASPPI=1
 PREFIX=arm-none-eabi-
 MULTICORE=0
@@ -50,22 +41,28 @@ QEMU=0
 CPP17=0
 DEFINE=
 FORCE=0
+SHIFT=0
 
-while true ; do
+while [ ${#} -gt 0 ]; do
 	case "$1" in
-		-r|--raspberrypi) RASPPI="$2" ; shift 2;;
-		-p|--prefix) PREFIX="$2" ; shift 2;;
-		--multicore) MULTICORE=1 ; shift;;
-		--realtime) REALTIME=1 ; shift;;
-		--keymap) KEYMAP="$2" ; shift 2;;
-		--qemu) QEMU=1 ; shift;;
-		--c++17) CPP17=1 ; shift;;
-		-d|--define) DEFINE="$DEFINE -D$2" ; shift 2;;
-		-f|--force) FORCE=1 ; shift;;
+		-r|--raspberrypi) RASPPI="$2" ; SHIFT=2;;
+		-p|--prefix) PREFIX="$2" ; SHIFT=2;;
+		--multicore) MULTICORE=1 ; SHIFT=1;;
+		--realtime) REALTIME=1 ; SHIFT=1;;
+		--keymap) KEYMAP="$2" ; SHIFT=2;;
+		--qemu) QEMU=1 ; SHIFT=1;;
+		--c++17) CPP17=1 ; SHIFT=1;;
+		-d|--define) DEFINE="$DEFINE -D$2" ; SHIFT=2;;
+		-f|--force) FORCE=1 ; SHIFT=1;;
 		-h|--help) usage ; exit 0;;
-		--) shift ; break ;;
-		*) echo "Internal error" ; exit 1;;
+		*) echo "Unknown argument: '$1'" >&2; usage >&2; exit 1;;
 	esac
+	if [ "${#}" -lt "${SHIFT}" ]; then
+		echo "'$1' requires an argument" >&2
+		usage >&2
+		exit 1
+	fi
+	shift "${SHIFT}"
 done
 
 if [ $RASPPI -eq 5 ]


### PR DESCRIPTION
The `configure` script depended on GNU `getopt` and was incompatible with macOS `getopt`. This patch removes the dependency, instead reporting parameter parsing failures directly in the bash script, to support macOS.