### PR TITLE
cflashy: macos compatibility

### DIFF
--- a/doc/bootloader.txt
+++ b/doc/bootloader.txt
@@ -143,8 +143,8 @@ Using the Flash Tool "cFlashy"
 -----------------------------
 
 Because of recent issues with npm packages, used by the original Flashy (v1), there is
-a similar tool as a native executable for Linux and Windows available now in the Circle
-project, which is called "cFlashy", and which supports the most important features of
+a similar tool as a native executable for Linux, Windows and macOS available now in the
+Circle project, which is called "cFlashy", and which supports the most important features of
 Flashy v1 in a compatible way.  To use it:
 
 In your Config.mk set the variable `USEFLASHY`, along with the other settings for Flashy v1:


### PR DESCRIPTION
It seems that macOS supports fewer serial baud rates than Linux, and so the incompatible baud rates have been removed when compiling under macOS.

```
pmoore@Peters-MacBook-Pro-2:~/git/circle fix-cflashy-macos $ cat /Library/Developer/CommandLineTools/SDKs/MacOSX14.4.sdk/usr/include/sys/termios.h | grep '#define B[0-9][0-9]*' | sort -n -k3
#define B0      0
#define B50     50
#define B75     75
#define B110    110
#define B134    134
#define B150    150
#define B200    200
#define B300    300
#define B600    600
#define B1200   1200
#define B1800   1800
#define B2400   2400
#define B4800   4800
#define B7200   7200
#define B9600   9600
#define B14400  14400
#define B19200  19200
#define B28800  28800
#define B38400  38400
#define B57600  57600
#define B76800  76800
#define B115200 115200
#define B230400 230400
```

I've only tested that this fixes the compilation. I have not tested the compiled binary, please let me know if that is required. Many thanks Rene!

Originally raised in #499.