### PR TITLE
Fix CPTR_EL3 to match raspberrypi/tools#123

### DIFF
--- a/boot/armstub/armstub8.S
+++ b/boot/armstub/armstub8.S
@@ -97,9 +97,8 @@ _start:
 	msr CNTVOFF_EL2, xzr
 
 	/* Enable FP/SIMD */
-	/* All set bits below are res1; bit 10 (TFP) is set to 0 */
-	mov x0, #0x33ff
-	msr CPTR_EL3, x0
+	/* bit 10 (TFP) set to 0 */
+	msr CPTR_EL3, xzr
 
 	/* Set up SCR */
 	mov x0, #SCR_VAL


### PR DESCRIPTION
While researching ARM register settings used in Circle, I noticed that RES0 bits were being set to 1 in [`CPTR_EL3`](https://developer.arm.com/documentation/ddi0601/2024-09/AArch64-Registers/CPTR-EL3--Architectural-Feature-Trap-Register--EL3-?lang=en). After comparing with raspberry pi official stub, I noticed this is something that was reported and fixed after the circle version was forked.

It looks like there may also be a couple of other fixes in armstub8.S upstream, but I haven't looked into too much detail. This seemed like a relatively isolated fix. I also haven't checked if there are fixed in the 32 bit stub since the fork.

See raspberrypi/tools#123 for the upstream fix.