### PR TITLE
Simplify and optimize memset on aarch64

### DIFF
--- a/lib/util_fast.S
+++ b/lib/util_fast.S
@@ -96,18 +96,16 @@ memset:
 	tst	x0, #7
 	b.ne	2f
 	cmp	x2, #16
-	b.lo	6f
+	b.lo	2f
 
 	orr	w8, w1, w1, lsl #8
 	orr	w9, w8, w8, lsl #16
 	mov	x10, x0
 
-1:	stp	w9, w9, [x10]
-	add	x8, x10, #16
+1:	stp	w9, w9, [x10], #8
 	sub	x2, x2, #16
 	cmp	x2, #15
-	stp	w9, w9, [x10, #8]
-	mov	x10, x8
+	stp	w9, w9, [x10], #8
 	b.hi	1b
 	b	3f
 
@@ -119,10 +117,6 @@ memset:
 	b.ne	4b
 
 5:	ret
-
-6:	mov	x8, x0
-	cbnz	x2, 4b
-	b	5b
 
 	.globl	memcpy
 	.type   memcpy, %function


### PR DESCRIPTION
Hi Rene!

I found a slight optimization/simplification to the aarch64 version of `memset`. In testing, the modified `memset` consistently ran ~25% faster. The benchmark code is [here](https://github.com/petemoore/circle/commit/6772502267b911a7045900f7854e3b99086c5ec8). The result on my Raspberry Pi 400 was:

```
logger: Circle 48 started on Raspberry Pi 400 4GB (AArch64)
logger: Revision code is c03130, compiler has been GCC 11.3.1
00:00:00.66 timer: SpeedFactor is 1.51
00:00:00.81 kernel: Benchmark result (memset): 20000 calls in 150263 microseconds
00:00:00.93 kernel: Benchmark result (memset): 20000 calls in 112856 microseconds
00:00:01.04 kernel: Benchmark result (memset): 20000 calls in 103139 microseconds
00:00:01.14 kernel: Benchmark result (memset): 20000 calls in 96290 microseconds
00:00:01.23 kernel: Benchmark result (memset): 20000 calls in 88012 microseconds
00:00:01.32 kernel: Benchmark result (memset): 20000 calls in 85819 microseconds
00:00:01.41 kernel: Benchmark result (memset): 20000 calls in 85818 microseconds
00:00:01.50 kernel: Benchmark result (memset): 20000 calls in 85818 microseconds
00:00:01.59 kernel: Benchmark result (memset): 20000 calls in 85814 microseconds
00:00:01.68 kernel: Benchmark result (memset): 20000 calls in 85815 microseconds
00:00:01.77 kernel: Benchmark result (memset): 20000 calls in 85814 microseconds
00:00:01.86 kernel: Benchmark result (memset): 20000 calls in 85813 microseconds
00:00:01.95 kernel: Benchmark result (memset): 20000 calls in 85813 microseconds
00:00:02.04 kernel: Benchmark result (memset): 20000 calls in 85813 microseconds
00:00:02.13 kernel: Benchmark result (memset): 20000 calls in 85813 microseconds
00:00:02.22 kernel: Benchmark result (memset): 20000 calls in 85812 microseconds
00:00:02.31 kernel: Benchmark result (memset): 20000 calls in 85812 microseconds
00:00:02.40 kernel: Benchmark result (memset): 20000 calls in 85812 microseconds
00:00:02.49 kernel: Benchmark result (memset): 20000 calls in 85812 microseconds
00:00:02.58 kernel: Benchmark result (memset): 20000 calls in 85812 microseconds
00:00:02.65 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:02.73 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:02.80 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:02.87 kernel: Benchmark result (memset2): 20000 calls in 68778 microseconds
00:00:02.95 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:03.02 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:03.09 kernel: Benchmark result (memset2): 20000 calls in 68779 microseconds
00:00:03.17 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:03.24 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:03.31 kernel: Benchmark result (memset2): 20000 calls in 68779 microseconds
00:00:03.39 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:03.46 kernel: Benchmark result (memset2): 20000 calls in 68779 microseconds
00:00:03.53 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:03.61 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:03.68 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:03.75 kernel: Benchmark result (memset2): 20000 calls in 68779 microseconds
00:00:03.82 kernel: Benchmark result (memset2): 20000 calls in 68778 microseconds
00:00:03.90 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:03.97 kernel: Benchmark result (memset2): 20000 calls in 68780 microseconds
00:00:04.04 kernel: Benchmark result (memset2): 20000 calls in 68778 microseconds
00:00:04.05 kernel: Benchmark complete.
```

Let me know what you think! :-)

Best wishes,
Pete