### PR TITLE
Simplify and optimize memset on aarch64

### DIFF
--- a/lib/util_fast.S
+++ b/lib/util_fast.S
@@ -93,36 +93,31 @@ memcpy:
 	.globl	memset
 	.type   memset, %function
 memset:
-	tst	x0, #7
-	b.ne	2f
-	cmp	x2, #16
-	b.lo	6f
-
-	orr	w8, w1, w1, lsl #8
-	orr	w9, w8, w8, lsl #16
+	cbz	x2, 3f
 	mov	x10, x0
 
-1:	stp	w9, w9, [x10]
-	add	x8, x10, #16
-	sub	x2, x2, #16
-	cmp	x2, #15
-	stp	w9, w9, [x10, #8]
-	mov	x10, x8
-	b.hi	1b
-	b	3f
+1:	tst	x10, #0x1f
+	b.eq	4f
 
-2:	mov	x8, x0
-3:	cbz	x2, 5f
+2:	strb	w1, [x10], #1
+	sub  	x2, x2, #1
+	cbnz	x2, 1b
 
-4:	subs	x2, x2, #1
-	strb	w1, [x8], #1
-	b.ne	4b
+3:	ret
 
-5:	ret
+4:	lsr	x9, x2, #5
+	and	x2, x2, #0x1f
+	cbz	x9, 6f
+	and	x1, x1, #0xff
+	mov	x8, #0x0101010101010101
+	mul	x8, x8, x1
 
-6:	mov	x8, x0
-	cbnz	x2, 4b
-	b	5b
+5:	sub	x9, x9, #1
+	stp	x8, x8, [x10], #0x10
+	stp	x8, x8, [x10], #0x10
+	cbnz	x9, 5b
+6:	cbz	x2, 3b
+	b	2b
 
 	.globl	memcpy
 	.type   memcpy, %function


### PR DESCRIPTION
The previous attempt in #526 was flawed. This version has been comprehensively tested!

This time I wrote a short circle application to call both the original memset and the new memset with randomly generated values, offsets and lengths, inside a fixed 32KB buffer. It then compares the full buffer (not just the part that memset updated) generated by both versions, and reports if there are any differences. Only if there are no differences, it then proceeds to benchmark both versions, to compare performance.

I'm happy to say that this was useful for a couple of reasons

1. It identified a bug in my new version that I hadn't seen when writing it by hand, which I was able to fix.
2. It identified a (minor) bug in the original implementation, which is also quite easy to fix.

The code for the tests and the benchmarks can be seen in the [test-memset2 branch](https://github.com/petemoore/circle/tree/test-memset2) of my fork, specifically commit [1e08e4639fe26f1d455e7de632c51f4c820a7659](https://github.com/petemoore/circle/commit/1e08e4639fe26f1d455e7de632c51f4c820a7659). This code can be run on any 64 bit raspberry pi. The performance numbers look good to me on a Raspberry Pi 400, I've not had the chance to test on any other hardware.

The bug in the original memset can be seen [here](https://github.com/petemoore/circle/commit/1e08e4639fe26f1d455e7de632c51f4c820a7659#diff-f3188526345620027ae80f315b8a3450eae51a63550128ff09c253f62ce6ac52R101). The bug is that `memset` is meant to treat the `int` value argument as an `unsigned char` (8 bit value) and discard the upper bits. If the address passed to memset was on an 8 byte boundary (the common case) but the int value passed through was > 255, it was not handled correctly, and the other set bits could end up polluting the updated memory region.

Here are the results of the benchmarks. Please note, the results may be slightly misleading, since in the common case memset would be called on an 8 byte aligned address, where it performs much better. But in the tests, the address is random, and so in 7/8 of the tests, the faster path isn't called, making the original memset look slower than it typically is.

The last point to note is that I have since discovered there are even better implementations, that utilise SIMD, such as [ARM's own optimised memset imlpementation](https://github.com/ARM-software/optimized-routines/blob/master/string/aarch64/memset.S). This may be worth looking at (together with the other optimised routines in there). The code in the test-memset2 branch (see above) could also be used to test and benchmark them, to get results for real raspberry pis! :-)

This is left as an exercise for the reader! 😆 ... Or maybe I will have a play with them for fun too, now that I have the framework for testing and comparing them.

Any questions, let me know. And thanks for your patience! :-)

Best wishes,
Pete

```
logger: Circle 48 started on Raspberry Pi 400 4GB (AArch64)
logger: Revision code is c03130, compiler has been GCC 11.3.1
00:00:00.66 timer: SpeedFactor is 1.51
00:00:00.66 kernel: Calling memset (0xa5572, 0x583e3ea7, 0x128)
00:00:00.67 kernel: Calling memset2 (0x9d572, 0x583e3ea7, 0x128)
00:00:00.67 kernel: Comparing results of memset and memset2...
00:00:00.68 kernel: Buffers match.
00:00:00.69 kernel: Benchmark result (memset): 20000 calls in 10235 microseconds
00:00:00.70 kernel: Benchmark result (memset2): 20000 calls in 2234 microseconds
00:00:00.70 kernel: Calling memset (0xa52ea, 0xbc12b189, 0x1dc8)
00:00:00.71 kernel: Calling memset2 (0x9d2ea, 0xbc12b189, 0x1dc8)
00:00:00.72 kernel: Comparing results of memset and memset2...
00:00:00.72 kernel: Buffers match.
00:00:00.98 kernel: Benchmark result (memset): 20000 calls in 254541 microseconds
00:00:01.00 kernel: Benchmark result (memset2): 20000 calls in 18253 microseconds
00:00:01.01 kernel: Calling memset (0xa09f4, 0x44a5118a, 0x312f)
00:00:01.01 kernel: Calling memset2 (0x989f4, 0x44a5118a, 0x312f)
00:00:01.02 kernel: Comparing results of memset and memset2...
00:00:01.02 kernel: Buffers match.
00:00:01.45 kernel: Benchmark result (memset): 20000 calls in 420133 microseconds
00:00:01.48 kernel: Benchmark result (memset2): 20000 calls in 27155 microseconds
00:00:01.48 kernel: Calling memset (0x9fdf1, 0xcb62bdf1, 0x2f3b)
00:00:01.49 kernel: Calling memset2 (0x97df1, 0xcb62bdf1, 0x2f3b)
00:00:01.49 kernel: Comparing results of memset and memset2...
00:00:01.50 kernel: Buffers match.
00:00:01.91 kernel: Benchmark result (memset): 20000 calls in 403465 microseconds
00:00:01.94 kernel: Benchmark result (memset2): 20000 calls in 26488 microseconds
00:00:01.94 kernel: Calling memset (0xa6405, 0x1c768fd4, 0xa5a)
00:00:01.95 kernel: Calling memset2 (0x9e405, 0x1c768fd4, 0xa5a)
00:00:01.95 kernel: Comparing results of memset and memset2...
00:00:01.96 kernel: Buffers match.
00:00:02.05 kernel: Benchmark result (memset): 20000 calls in 88714 microseconds
00:00:02.06 kernel: Benchmark result (memset2): 20000 calls in 8185 microseconds
00:00:02.07 kernel: Calling memset (0xa33d4, 0x7e7a06e6, 0xb0e)
00:00:02.07 kernel: Calling memset2 (0x9b3d4, 0x7e7a06e6, 0xb0e)
00:00:02.08 kernel: Comparing results of memset and memset2...
00:00:02.08 kernel: Buffers match.
00:00:02.18 kernel: Benchmark result (memset): 20000 calls in 94714 microseconds
00:00:02.19 kernel: Benchmark result (memset2): 20000 calls in 6766 microseconds
00:00:02.20 kernel: Calling memset (0xa3fe3, 0xeee9487d, 0x33f7)
00:00:02.20 kernel: Calling memset2 (0x9bfe3, 0xeee9487d, 0x33f7)
00:00:02.21 kernel: Comparing results of memset and memset2...
00:00:02.21 kernel: Buffers match.
00:00:02.66 kernel: Benchmark result (memset): 20000 calls in 443870 microseconds
00:00:02.70 kernel: Benchmark result (memset2): 20000 calls in 30290 microseconds
00:00:02.70 kernel: Calling memset (0x9f991, 0xb1bed921, 0xb1e)
00:00:02.71 kernel: Calling memset2 (0x97991, 0xb1bed921, 0xb1e)
00:00:02.71 kernel: Comparing results of memset and memset2...
00:00:02.72 kernel: Buffers match.
00:00:02.81 kernel: Benchmark result (memset): 20000 calls in 95247 microseconds
00:00:02.83 kernel: Benchmark result (memset2): 20000 calls in 7318 microseconds
00:00:02.83 kernel: Calling memset (0xa0a38, 0xf4a2eb2e, 0x2770)
00:00:02.84 kernel: Calling memset2 (0x98a38, 0xf4a2eb2e, 0x2770)
00:00:02.84 kernel: Comparing results of memset and memset2...
00:00:02.85 kernel: Buffers match.
00:00:02.88 kernel: Benchmark result (memset): 20000 calls in 32022 microseconds
00:00:02.91 kernel: Benchmark result (memset2): 20000 calls in 22091 microseconds
00:00:02.91 kernel: Calling memset (0xa5888, 0x50e9af8a, 0x644)
00:00:02.92 kernel: Calling memset2 (0x9d888, 0x50e9af8a, 0x644)
00:00:02.93 kernel: Comparing results of memset and memset2...
00:00:02.93 kernel: Buffers match.
00:00:02.94 kernel: Benchmark result (memset): 20000 calls in 5602 microseconds
00:00:02.95 kernel: Benchmark result (memset2): 20000 calls in 5085 microseconds
00:00:02.95 kernel: Calling memset (0xa6edd, 0x45eae520, 0x473)
00:00:02.96 kernel: Calling memset2 (0x9eedd, 0x45eae520, 0x473)
00:00:02.96 kernel: Comparing results of memset and memset2...
00:00:02.97 kernel: Buffers match.
00:00:03.01 kernel: Benchmark result (memset): 20000 calls in 38340 microseconds
00:00:03.02 kernel: Benchmark result (memset2): 20000 calls in 3417 microseconds
00:00:03.02 kernel: Calling memset (0x9fc8a, 0x9f29135e, 0x830)
00:00:03.03 kernel: Calling memset2 (0x97c8a, 0x9f29135e, 0x830)
00:00:03.03 kernel: Comparing results of memset and memset2...
00:00:03.04 kernel: Buffers match.
00:00:03.11 kernel: Benchmark result (memset): 20000 calls in 70244 microseconds
00:00:03.12 kernel: Benchmark result (memset2): 20000 calls in 6717 microseconds
00:00:03.13 kernel: Calling memset (0xa51f0, 0xdd6f91ea, 0xd6a)
00:00:03.13 kernel: Calling memset2 (0x9d1f0, 0xdd6f91ea, 0xd6a)
00:00:03.14 kernel: Comparing results of memset and memset2...
00:00:03.15 kernel: Buffers match.
00:00:03.16 kernel: Benchmark result (memset): 20000 calls in 11502 microseconds
00:00:03.17 kernel: Benchmark result (memset2): 20000 calls in 9318 microseconds
00:00:03.18 kernel: Calling memset (0xa46ad, 0x7ad65830, 0x8e3)
00:00:03.18 kernel: Calling memset2 (0x9c6ad, 0x7ad65830, 0x8e3)
00:00:03.19 kernel: Comparing results of memset and memset2...
00:00:03.20 kernel: Buffers match.
00:00:03.27 kernel: Benchmark result (memset): 20000 calls in 76212 microseconds
00:00:03.29 kernel: Benchmark result (memset2): 20000 calls in 6452 microseconds
00:00:03.29 kernel: Calling memset (0xa4633, 0xabe5886, 0x1e18)
00:00:03.30 kernel: Calling memset2 (0x9c633, 0xabe5886, 0x1e18)
00:00:03.30 kernel: Comparing results of memset and memset2...
00:00:03.31 kernel: Buffers match.
00:00:03.57 kernel: Benchmark result (memset): 20000 calls in 257208 microseconds
00:00:03.59 kernel: Benchmark result (memset2): 20000 calls in 17253 microseconds
00:00:03.59 kernel: Calling memset (0xa49d1, 0x47076632, 0x174a)
00:00:03.60 kernel: Calling memset2 (0x9c9d1, 0x47076632, 0x174a)
00:00:03.60 kernel: Comparing results of memset and memset2...
00:00:03.61 kernel: Buffers match.
00:00:03.81 kernel: Benchmark result (memset): 20000 calls in 199132 microseconds
00:00:03.83 kernel: Benchmark result (memset2): 20000 calls in 14402 microseconds
00:00:03.84 kernel: Calling memset (0xa4fb3, 0x209a6170, 0x184e)
00:00:03.84 kernel: Calling memset2 (0x9cfb3, 0x209a6170, 0x184e)
00:00:03.85 kernel: Comparing results of memset and memset2...
00:00:03.85 kernel: Buffers match.
00:00:04.06 kernel: Benchmark result (memset): 20000 calls in 207798 microseconds
00:00:04.08 kernel: Benchmark result (memset2): 20000 calls in 13835 microseconds
00:00:04.09 kernel: Calling memset (0xa6390, 0xc29ec362, 0x879)
00:00:04.09 kernel: Calling memset2 (0x9e390, 0xc29ec362, 0x879)
00:00:04.10 kernel: Comparing results of memset and memset2...
00:00:04.10 kernel: Buffers match.
00:00:04.11 kernel: Benchmark result (memset): 20000 calls in 7517 microseconds
00:00:04.12 kernel: Benchmark result (memset2): 20000 calls in 5750 microseconds
00:00:04.13 kernel: Calling memset (0xa3576, 0x8c8b2a2c, 0x13e2)
00:00:04.13 kernel: Calling memset2 (0x9b576, 0x8c8b2a2c, 0x13e2)
00:00:04.14 kernel: Comparing results of memset and memset2...
00:00:04.14 kernel: Buffers match.
00:00:04.32 kernel: Benchmark result (memset): 20000 calls in 170060 microseconds
00:00:04.33 kernel: Benchmark result (memset2): 20000 calls in 12335 microseconds
00:00:04.34 kernel: Calling memset (0xa1898, 0x857ce9e8, 0x1ace)
00:00:04.34 kernel: Calling memset2 (0x99898, 0x857ce9e8, 0x1ace)
00:00:04.35 kernel: Comparing results of memset and memset2...
00:00:04.36 kernel: Buffers match.
00:00:04.38 kernel: Benchmark result (memset): 20000 calls in 22337 microseconds
00:00:04.40 kernel: Benchmark result (memset2): 20000 calls in 15366 microseconds
00:00:04.41 kernel: Calling memset (0xa2a1c, 0xf016750f, 0x2a2)
00:00:04.41 kernel: Calling memset2 (0x9aa1c, 0xf016750f, 0x2a2)
00:00:04.42 kernel: Comparing results of memset and memset2...
00:00:04.42 kernel: Buffers match.
00:00:04.45 kernel: Benchmark result (memset): 20000 calls in 22837 microseconds
00:00:04.46 kernel: Benchmark result (memset2): 20000 calls in 2802 microseconds
00:00:04.46 kernel: Calling memset (0xa3173, 0x7db8aa34, 0x119c)
00:00:04.47 kernel: Calling memset2 (0x9b173, 0x7db8aa34, 0x119c)
00:00:04.47 kernel: Comparing results of memset and memset2...
00:00:04.48 kernel: Buffers match.
00:00:04.63 kernel: Benchmark result (memset): 20000 calls in 150658 microseconds
00:00:04.65 kernel: Benchmark result (memset2): 20000 calls in 10720 microseconds
00:00:04.65 kernel: Calling memset (0xa5225, 0xd0d698b0, 0x1c3f)
00:00:04.66 kernel: Calling memset2 (0x9d225, 0xd0d698b0, 0x1c3f)
00:00:04.66 kernel: Comparing results of memset and memset2...
00:00:04.67 kernel: Buffers match.
00:00:04.91 kernel: Benchmark result (memset): 20000 calls in 241438 microseconds
00:00:04.93 kernel: Benchmark result (memset2): 20000 calls in 16652 microseconds
00:00:04.94 kernel: Calling memset (0xa5d5a, 0xfa9a5437, 0x256)
00:00:04.94 kernel: Calling memset2 (0x9dd5a, 0xfa9a5437, 0x256)
00:00:04.95 kernel: Comparing results of memset and memset2...
00:00:04.95 kernel: Buffers match.
00:00:04.98 kernel: Benchmark result (memset): 20000 calls in 20303 microseconds
00:00:04.98 kernel: Benchmark result (memset2): 20000 calls in 1900 microseconds
00:00:04.99 kernel: Calling memset (0xa49a6, 0xd0b8a968, 0x1ddf)
00:00:04.99 kernel: Calling memset2 (0x9c9a6, 0xd0b8a968, 0x1ddf)
00:00:05.00 kernel: Comparing results of memset and memset2...
00:00:05.01 kernel: Buffers match.
00:00:05.26 kernel: Benchmark result (memset): 20000 calls in 255306 microseconds
00:00:05.29 kernel: Benchmark result (memset2): 20000 calls in 17520 microseconds
00:00:05.29 kernel: Calling memset (0xa06c2, 0xf34d87f7, 0x4c5e)
00:00:05.30 kernel: Calling memset2 (0x986c2, 0xf34d87f7, 0x4c5e)
00:00:05.30 kernel: Comparing results of memset and memset2...
00:00:05.31 kernel: Buffers match.
00:00:05.96 kernel: Benchmark result (memset): 20000 calls in 652136 microseconds
00:00:06.01 kernel: Benchmark result (memset2): 20000 calls in 42257 microseconds
00:00:06.01 kernel: Calling memset (0xa4a32, 0x5e1eea43, 0x28be)
00:00:06.02 kernel: Calling memset2 (0x9ca32, 0x5e1eea43, 0x28be)
00:00:06.03 kernel: Comparing results of memset and memset2...
00:00:06.03 kernel: Buffers match.
00:00:06.38 kernel: Benchmark result (memset): 20000 calls in 348089 microseconds
00:00:06.41 kernel: Benchmark result (memset2): 20000 calls in 23120 microseconds
00:00:06.41 kernel: Calling memset (0x9ff38, 0x93a74571, 0x2cac)
00:00:06.42 kernel: Calling memset2 (0x97f38, 0x93a74571, 0x2cac)
00:00:06.43 kernel: Comparing results of memset and memset2...
00:00:06.43 kernel: Buffers match.
00:00:06.47 kernel: Benchmark result (memset): 20000 calls in 36574 microseconds
00:00:06.50 kernel: Benchmark result (memset2): 20000 calls in 24653 microseconds
00:00:06.50 kernel: Calling memset (0xa171d, 0x108abf95, 0x26c6)
00:00:06.51 kernel: Calling memset2 (0x9971d, 0x108abf95, 0x26c6)
00:00:06.52 kernel: Comparing results of memset and memset2...
00:00:06.52 kernel: Buffers match.
00:00:06.86 kernel: Benchmark result (memset): 20000 calls in 331287 microseconds
00:00:06.88 kernel: Benchmark result (memset2): 20000 calls in 21320 microseconds
00:00:06.89 kernel: Calling memset (0xa220f, 0xa78a5741, 0x604)
00:00:06.89 kernel: Calling memset2 (0x9a20f, 0xa78a5741, 0x604)
00:00:06.90 kernel: Comparing results of memset and memset2...
00:00:06.90 kernel: Buffers match.
00:00:06.96 kernel: Benchmark result (memset): 20000 calls in 51708 microseconds
00:00:06.97 kernel: Benchmark result (memset2): 20000 calls in 5718 microseconds
00:00:06.97 kernel: Calling memset (0xa5a29, 0xd4d75d7a, 0x596)
00:00:06.98 kernel: Calling memset2 (0x9da29, 0xd4d75d7a, 0x596)
00:00:06.98 kernel: Comparing results of memset and memset2...
00:00:06.99 kernel: Buffers match.
00:00:07.04 kernel: Benchmark result (memset): 20000 calls in 48041 microseconds
00:00:07.05 kernel: Benchmark result (memset2): 20000 calls in 5519 microseconds
00:00:07.05 kernel: Calling memset (0xa45d6, 0xdd0da698, 0x1e28)
00:00:07.06 kernel: Calling memset2 (0x9c5d6, 0xdd0da698, 0x1e28)
00:00:07.07 kernel: Comparing results of memset and memset2...
00:00:07.07 kernel: Buffers match.
00:00:07.33 kernel: Benchmark result (memset): 20000 calls in 257741 microseconds
00:00:07.35 kernel: Benchmark result (memset2): 20000 calls in 18002 microseconds
00:00:07.36 kernel: Calling memset (0x9f7b8, 0x34333164, 0x5d47)
00:00:07.36 kernel: Calling memset2 (0x977b8, 0x34333164, 0x5d47)
00:00:07.37 kernel: Comparing results of memset and memset2...
00:00:07.38 kernel: Buffers match.
00:00:07.45 kernel: Benchmark result (memset): 20000 calls in 75311 microseconds
00:00:07.51 kernel: Benchmark result (memset2): 20000 calls in 51738 microseconds
00:00:07.51 kernel: Calling memset (0xa5949, 0x83fb1e40, 0xc5c)
00:00:07.52 kernel: Calling memset2 (0x9d949, 0x83fb1e40, 0xc5c)
00:00:07.53 kernel: Comparing results of memset and memset2...
00:00:07.53 kernel: Buffers match.
00:00:07.64 kernel: Benchmark result (memset): 20000 calls in 105851 microseconds
00:00:07.65 kernel: Benchmark result (memset2): 20000 calls in 8085 microseconds
00:00:07.66 kernel: Calling memset (0xa0e54, 0xce57f011, 0x5bd8)
00:00:07.66 kernel: Calling memset2 (0x98e54, 0xce57f011, 0x5bd8)
00:00:07.67 kernel: Comparing results of memset and memset2...
00:00:07.67 kernel: Buffers match.
00:00:08.46 kernel: Benchmark result (memset): 20000 calls in 784222 microseconds
00:00:08.52 kernel: Benchmark result (memset2): 20000 calls in 50192 microseconds
00:00:08.52 kernel: Calling memset (0xa5061, 0xb8e95ee8, 0x9d3)
00:00:08.53 kernel: Calling memset2 (0x9d061, 0xb8e95ee8, 0x9d3)
00:00:08.53 kernel: Comparing results of memset and memset2...
00:00:08.54 kernel: Buffers match.
00:00:08.62 kernel: Benchmark result (memset): 20000 calls in 84213 microseconds
00:00:08.64 kernel: Benchmark result (memset2): 20000 calls in 7685 microseconds
00:00:08.64 kernel: Calling memset (0xa6e88, 0xbf6d61e0, 0x56a)
00:00:08.65 kernel: Calling memset2 (0x9ee88, 0xbf6d61e0, 0x56a)
00:00:08.65 kernel: Comparing results of memset and memset2...
00:00:08.66 kernel: Buffers match.
00:00:08.67 kernel: Benchmark result (memset): 20000 calls in 5102 microseconds
00:00:08.68 kernel: Benchmark result (memset2): 20000 calls in 5318 microseconds
00:00:08.68 kernel: Calling memset (0xa7209, 0x9ae06bc3, 0x2e9)
00:00:08.69 kernel: Calling memset2 (0x9f209, 0x9ae06bc3, 0x2e9)
00:00:08.69 kernel: Comparing results of memset and memset2...
00:00:08.70 kernel: Buffers match.
00:00:08.73 kernel: Benchmark result (memset): 20000 calls in 25205 microseconds
00:00:08.73 kernel: Benchmark result (memset2): 20000 calls in 3683 microseconds
00:00:08.74 kernel: Calling memset (0xa4ffd, 0xec219cc9, 0x3bf)
00:00:08.74 kernel: Calling memset2 (0x9cffd, 0xec219cc9, 0x3bf)
00:00:08.75 kernel: Comparing results of memset and memset2...
00:00:08.75 kernel: Buffers match.
00:00:08.79 kernel: Benchmark result (memset): 20000 calls in 32338 microseconds
00:00:08.80 kernel: Benchmark result (memset2): 20000 calls in 3302 microseconds
00:00:08.80 kernel: Calling memset (0xa340c, 0xe197ffdc, 0x2ad5)
00:00:08.81 kernel: Calling memset2 (0x9b40c, 0xe197ffdc, 0x2ad5)
00:00:08.81 kernel: Comparing results of memset and memset2...
00:00:08.82 kernel: Buffers match.
00:00:09.19 kernel: Benchmark result (memset): 20000 calls in 365925 microseconds
00:00:09.22 kernel: Benchmark result (memset2): 20000 calls in 24122 microseconds
00:00:09.22 kernel: Calling memset (0xa175b, 0xde61ed37, 0x43d8)
00:00:09.23 kernel: Calling memset2 (0x9975b, 0xde61ed37, 0x43d8)
00:00:09.23 kernel: Comparing results of memset and memset2...
00:00:09.24 kernel: Buffers match.
00:00:09.82 kernel: Benchmark result (memset): 20000 calls in 579391 microseconds
00:00:09.86 kernel: Benchmark result (memset2): 20000 calls in 37873 microseconds
00:00:09.87 kernel: Calling memset (0xa1464, 0xbff1c578, 0x2604)
00:00:09.87 kernel: Calling memset2 (0x99464, 0xbff1c578, 0x2604)
00:00:09.88 kernel: Comparing results of memset and memset2...
00:00:09.88 kernel: Buffers match.
00:00:10.21 kernel: Benchmark result (memset): 20000 calls in 324817 microseconds
00:00:10.24 kernel: Benchmark result (memset2): 20000 calls in 22020 microseconds
00:00:10.24 kernel: Calling memset (0xa0391, 0xe53ff2e2, 0x3fb2)
00:00:10.25 kernel: Calling memset2 (0x98391, 0xe53ff2e2, 0x3fb2)
00:00:10.25 kernel: Comparing results of memset and memset2...
00:00:10.26 kernel: Buffers match.
00:00:10.81 kernel: Benchmark result (memset): 20000 calls in 543987 microseconds
00:00:10.85 kernel: Benchmark result (memset2): 20000 calls in 34990 microseconds
00:00:10.85 kernel: Calling memset (0xa35e2, 0x5014fde6, 0x1456)
00:00:10.86 kernel: Calling memset2 (0x9b5e2, 0x5014fde6, 0x1456)
00:00:10.86 kernel: Comparing results of memset and memset2...
00:00:10.87 kernel: Buffers match.
00:00:11.04 kernel: Benchmark result (memset): 20000 calls in 173927 microseconds
00:00:11.06 kernel: Benchmark result (memset2): 20000 calls in 13385 microseconds
00:00:11.07 kernel: Calling memset (0xa3580, 0x947bb20c, 0x1199)
00:00:11.07 kernel: Calling memset2 (0x9b580, 0x947bb20c, 0x1199)
00:00:11.08 kernel: Comparing results of memset and memset2...
00:00:11.08 kernel: Buffers match.
00:00:11.10 kernel: Benchmark result (memset): 20000 calls in 14818 microseconds
00:00:11.12 kernel: Benchmark result (memset2): 20000 calls in 10735 microseconds
00:00:11.12 kernel: Calling memset (0xa4eb5, 0x1dc8ca1d, 0x12a)
00:00:11.13 kernel: Calling memset2 (0x9ceb5, 0x1dc8ca1d, 0x12a)
00:00:11.13 kernel: Comparing results of memset and memset2...
00:00:11.14 kernel: Buffers match.
00:00:11.15 kernel: Benchmark result (memset): 20000 calls in 10301 microseconds
00:00:11.16 kernel: Benchmark result (memset2): 20000 calls in 2300 microseconds
00:00:11.16 kernel: Calling memset (0xa1205, 0x66bd282d, 0x55b9)
00:00:11.17 kernel: Calling memset2 (0x99205, 0x66bd282d, 0x55b9)
00:00:11.17 kernel: Comparing results of memset and memset2...
00:00:11.18 kernel: Buffers match.
00:00:11.91 kernel: Benchmark result (memset): 20000 calls in 731981 microseconds
00:00:11.97 kernel: Benchmark result (memset2): 20000 calls in 48358 microseconds
00:00:11.97 kernel: Calling memset (0xa5771, 0x3909007d, 0x899)
00:00:11.98 kernel: Calling memset2 (0x9d771, 0x3909007d, 0x899)
00:00:11.98 kernel: Comparing results of memset and memset2...
00:00:11.99 kernel: Buffers match.
00:00:12.07 kernel: Benchmark result (memset): 20000 calls in 73747 microseconds
00:00:12.08 kernel: Benchmark result (memset2): 20000 calls in 5819 microseconds
00:00:12.08 kernel: Calling memset (0xa4cf6, 0xcbc21aa4, 0x1f8e)
00:00:12.09 kernel: Calling memset2 (0x9ccf6, 0xcbc21aa4, 0x1f8e)
00:00:12.09 kernel: Comparing results of memset and memset2...
00:00:12.10 kernel: Buffers match.
00:00:12.37 kernel: Benchmark result (memset): 20000 calls in 269676 microseconds
00:00:12.39 kernel: Benchmark result (memset2): 20000 calls in 17720 microseconds
00:00:12.40 kernel: Calling memset (0xa73a5, 0x6f656c86, 0xd)
00:00:12.40 kernel: Calling memset2 (0x9f3a5, 0x6f656c86, 0xd)
00:00:12.41 kernel: Comparing results of memset and memset2...
00:00:12.41 kernel: Buffers match.
00:00:12.42 kernel: Benchmark result (memset): 20000 calls in 601 microseconds
00:00:12.42 kernel: Benchmark result (memset2): 20000 calls in 600 microseconds
00:00:12.43 kernel: Calling memset (0xa6573, 0xdcd118cd, 0x1ea)
00:00:12.44 kernel: Calling memset2 (0x9e573, 0xdcd118cd, 0x1ea)
00:00:12.44 kernel: Comparing results of memset and memset2...
00:00:12.45 kernel: Buffers match.
00:00:12.47 kernel: Benchmark result (memset): 20000 calls in 16704 microseconds
00:00:12.47 kernel: Benchmark result (memset2): 20000 calls in 2667 microseconds
00:00:12.48 kernel: Calling memset (0xa3242, 0x1e9bbf8a, 0x2f18)
00:00:12.48 kernel: Calling memset2 (0x9b242, 0x1e9bbf8a, 0x2f18)
00:00:12.49 kernel: Comparing results of memset and memset2...
00:00:12.50 kernel: Buffers match.
00:00:12.90 kernel: Benchmark result (memset): 20000 calls in 402297 microseconds
00:00:12.93 kernel: Benchmark result (memset2): 20000 calls in 27720 microseconds
00:00:12.94 kernel: Calling memset (0xa6b5e, 0x1feee3a5, 0x847)
00:00:12.94 kernel: Calling memset2 (0x9eb5e, 0x1feee3a5, 0x847)
00:00:12.95 kernel: Comparing results of memset and memset2...
00:00:12.95 kernel: Buffers match.
00:00:13.03 kernel: Benchmark result (memset): 20000 calls in 71011 microseconds
00:00:13.04 kernel: Benchmark result (memset2): 20000 calls in 5085 microseconds
00:00:13.04 kernel: Calling memset (0xa0b09, 0x1f577b5f, 0x1bf7)
00:00:13.05 kernel: Calling memset2 (0x98b09, 0x1f577b5f, 0x1bf7)
00:00:13.05 kernel: Comparing results of memset and memset2...
00:00:13.06 kernel: Buffers match.
00:00:13.30 kernel: Benchmark result (memset): 20000 calls in 239038 microseconds
00:00:13.32 kernel: Benchmark result (memset2): 20000 calls in 16219 microseconds
00:00:13.33 kernel: Calling memset (0xa57f6, 0x634b6728, 0xf7b)
00:00:13.33 kernel: Calling memset2 (0x9d7f6, 0x634b6728, 0xf7b)
00:00:13.34 kernel: Comparing results of memset and memset2...
00:00:13.34 kernel: Buffers match.
00:00:13.48 kernel: Benchmark result (memset): 20000 calls in 132488 microseconds
00:00:13.49 kernel: Benchmark result (memset2): 20000 calls in 9552 microseconds
00:00:13.50 kernel: Calling memset (0xa3380, 0x4b6bb99d, 0x33a8)
00:00:13.50 kernel: Calling memset2 (0x9b380, 0x4b6bb99d, 0x33a8)
00:00:13.51 kernel: Comparing results of memset and memset2...
00:00:13.51 kernel: Buffers match.
00:00:13.56 kernel: Benchmark result (memset): 20000 calls in 42040 microseconds
00:00:13.59 kernel: Benchmark result (memset2): 20000 calls in 28155 microseconds
00:00:13.60 kernel: Calling memset (0xa0f3d, 0x9ff88ad8, 0xd62)
00:00:13.60 kernel: Calling memset2 (0x98f3d, 0x9ff88ad8, 0xd62)
00:00:13.61 kernel: Comparing results of memset and memset2...
00:00:13.61 kernel: Buffers match.
00:00:13.73 kernel: Benchmark result (memset): 20000 calls in 114584 microseconds
00:00:13.74 kernel: Benchmark result (memset2): 20000 calls in 8868 microseconds
00:00:13.75 kernel: Calling memset (0xa118c, 0xe2409fe8, 0x5a0a)
00:00:13.75 kernel: Calling memset2 (0x9918c, 0xe2409fe8, 0x5a0a)
00:00:13.76 kernel: Comparing results of memset and memset2...
00:00:13.77 kernel: Buffers match.
00:00:14.54 kernel: Benchmark result (memset): 20000 calls in 768821 microseconds
00:00:14.59 kernel: Benchmark result (memset2): 20000 calls in 50192 microseconds
00:00:14.60 kernel: Calling memset (0xa1eb7, 0xfabe5ea1, 0xc44)
00:00:14.60 kernel: Calling memset2 (0x99eb7, 0xfabe5ea1, 0xc44)
00:00:14.61 kernel: Comparing results of memset and memset2...
00:00:14.61 kernel: Buffers match.
00:00:14.72 kernel: Benchmark result (memset): 20000 calls in 105049 microseconds
00:00:14.73 kernel: Benchmark result (memset2): 20000 calls in 8333 microseconds
00:00:14.74 kernel: Calling memset (0xa2081, 0x3b2e2047, 0x1ffc)
00:00:14.74 kernel: Calling memset2 (0x9a081, 0x3b2e2047, 0x1ffc)
00:00:14.75 kernel: Comparing results of memset and memset2...
00:00:14.76 kernel: Buffers match.
00:00:15.03 kernel: Benchmark result (memset): 20000 calls in 273343 microseconds
00:00:15.06 kernel: Benchmark result (memset2): 20000 calls in 19787 microseconds
00:00:15.06 kernel: Calling memset (0xa2106, 0x838d0e19, 0x3b6a)
00:00:15.07 kernel: Calling memset2 (0x9a106, 0x838d0e19, 0x3b6a)
00:00:15.07 kernel: Comparing results of memset and memset2...
00:00:15.08 kernel: Buffers match.
00:00:15.59 kernel: Benchmark result (memset): 20000 calls in 507447 microseconds
00:00:15.63 kernel: Benchmark result (memset2): 20000 calls in 33623 microseconds
00:00:15.63 kernel: Calling memset (0x9f96f, 0xcd5581f2, 0x4b9a)
00:00:15.64 kernel: Calling memset2 (0x9796f, 0xcd5581f2, 0x4b9a)
00:00:15.64 kernel: Comparing results of memset and memset2...
00:00:15.65 kernel: Buffers match.
00:00:16.30 kernel: Benchmark result (memset): 20000 calls in 645602 microseconds
00:00:16.34 kernel: Benchmark result (memset2): 20000 calls in 41857 microseconds
00:00:16.35 kernel: Calling memset (0xa0c29, 0xec9be00, 0x4c0c)
00:00:16.35 kernel: Calling memset2 (0x98c29, 0xec9be00, 0x4c0c)
00:00:16.36 kernel: Comparing results of memset and memset2...
00:00:16.36 kernel: Buffers match.
00:00:17.02 kernel: Benchmark result (memset): 20000 calls in 649402 microseconds
00:00:17.06 kernel: Benchmark result (memset2): 20000 calls in 42790 microseconds
00:00:17.07 kernel: Calling memset (0xa2bd7, 0xdf1e282e, 0x437)
00:00:17.07 kernel: Calling memset2 (0x9abd7, 0xdf1e282e, 0x437)
00:00:17.08 kernel: Comparing results of memset and memset2...
00:00:17.08 kernel: Buffers match.
00:00:17.12 kernel: Benchmark result (memset): 20000 calls in 36338 microseconds
00:00:17.13 kernel: Benchmark result (memset2): 20000 calls in 3284 microseconds
00:00:17.14 kernel: Calling memset (0xa0bd7, 0xbb1977ab, 0x92e)
00:00:17.14 kernel: Calling memset2 (0x98bd7, 0xbb1977ab, 0x92e)
00:00:17.15 kernel: Comparing results of memset and memset2...
00:00:17.15 kernel: Buffers match.
00:00:17.23 kernel: Benchmark result (memset): 20000 calls in 78711 microseconds
00:00:17.24 kernel: Benchmark result (memset2): 20000 calls in 5783 microseconds
00:00:17.25 kernel: Calling memset (0xa7191, 0x56937052, 0x66)
00:00:17.25 kernel: Calling memset2 (0x9f191, 0x56937052, 0x66)
00:00:17.26 kernel: Comparing results of memset and memset2...
00:00:17.27 kernel: Buffers match.
00:00:17.27 kernel: Benchmark result (memset): 20000 calls in 3767 microseconds
00:00:17.28 kernel: Benchmark result (memset2): 20000 calls in 2101 microseconds
00:00:17.28 kernel: Calling memset (0xa7146, 0x8ca32878, 0x268)
00:00:17.29 kernel: Calling memset2 (0x9f146, 0x8ca32878, 0x268)
00:00:17.30 kernel: Comparing results of memset and memset2...
00:00:17.30 kernel: Buffers match.
00:00:17.32 kernel: Benchmark result (memset): 20000 calls in 20904 microseconds
00:00:17.33 kernel: Benchmark result (memset2): 20000 calls in 2784 microseconds
00:00:17.34 kernel: Calling memset (0xa0ba8, 0x62581417, 0x2e9a)
00:00:17.34 kernel: Calling memset2 (0x98ba8, 0x62581417, 0x2e9a)
00:00:17.35 kernel: Comparing results of memset and memset2...
00:00:17.35 kernel: Buffers match.
00:00:17.39 kernel: Benchmark result (memset): 20000 calls in 38054 microseconds
00:00:17.43 kernel: Benchmark result (memset2): 20000 calls in 26505 microseconds
00:00:17.43 kernel: Calling memset (0xa38ce, 0x948b1997, 0x189d)
00:00:17.44 kernel: Calling memset2 (0x9b8ce, 0x948b1997, 0x189d)
00:00:17.44 kernel: Comparing results of memset and memset2...
00:00:17.45 kernel: Buffers match.
00:00:17.66 kernel: Benchmark result (memset): 20000 calls in 210433 microseconds
00:00:17.68 kernel: Benchmark result (memset2): 20000 calls in 14936 microseconds
00:00:17.68 kernel: Calling memset (0xa4f66, 0x7addaee8, 0x1a17)
00:00:17.69 kernel: Calling memset2 (0x9cf66, 0x7addaee8, 0x1a17)
00:00:17.70 kernel: Comparing results of memset and memset2...
00:00:17.70 kernel: Buffers match.
00:00:17.93 kernel: Benchmark result (memset): 20000 calls in 223037 microseconds
00:00:17.95 kernel: Benchmark result (memset2): 20000 calls in 16486 microseconds
00:00:17.95 kernel: Calling memset (0xa0eef, 0xf1f1e22c, 0x1969)
00:00:17.96 kernel: Calling memset2 (0x98eef, 0xf1f1e22c, 0x1969)
00:00:17.96 kernel: Comparing results of memset and memset2...
00:00:17.97 kernel: Buffers match.
00:00:18.19 kernel: Benchmark result (memset): 20000 calls in 217235 microseconds
00:00:18.21 kernel: Benchmark result (memset2): 20000 calls in 15687 microseconds
00:00:18.21 kernel: Calling memset (0xa1295, 0xdce7544d, 0xe38)
00:00:18.22 kernel: Calling memset2 (0x99295, 0xdce7544d, 0xe38)
00:00:18.23 kernel: Comparing results of memset and memset2...
00:00:18.23 kernel: Buffers match.
00:00:18.36 kernel: Benchmark result (memset): 20000 calls in 121720 microseconds
00:00:18.37 kernel: Benchmark result (memset2): 20000 calls in 8785 microseconds
00:00:18.37 kernel: Calling memset (0xa44d7, 0xd22be697, 0x1051)
00:00:18.38 kernel: Calling memset2 (0x9c4d7, 0xd22be697, 0x1051)
00:00:18.38 kernel: Comparing results of memset and memset2...
00:00:18.39 kernel: Buffers match.
00:00:18.53 kernel: Benchmark result (memset): 20000 calls in 139622 microseconds
00:00:18.55 kernel: Benchmark result (memset2): 20000 calls in 9685 microseconds
00:00:18.55 kernel: Calling memset (0xa51bc, 0x32e5ce15, 0x1b39)
00:00:18.56 kernel: Calling memset2 (0x9d1bc, 0x32e5ce15, 0x1b39)
00:00:18.56 kernel: Comparing results of memset and memset2...
00:00:18.57 kernel: Buffers match.
00:00:18.80 kernel: Benchmark result (memset): 20000 calls in 232703 microseconds
00:00:18.82 kernel: Benchmark result (memset2): 20000 calls in 15968 microseconds
00:00:18.83 kernel: Calling memset (0xa081e, 0xe17774c7, 0x5de3)
00:00:18.83 kernel: Calling memset2 (0x9881e, 0xe17774c7, 0x5de3)
00:00:18.84 kernel: Comparing results of memset and memset2...
00:00:18.85 kernel: Buffers match.
00:00:19.65 kernel: Benchmark result (memset): 20000 calls in 801659 microseconds
00:00:19.71 kernel: Benchmark result (memset2): 20000 calls in 50608 microseconds
00:00:19.71 kernel: Calling memset (0xa3231, 0xf288f690, 0x17b3)
00:00:19.72 kernel: Calling memset2 (0x9b231, 0xf288f690, 0x17b3)
00:00:19.72 kernel: Comparing results of memset and memset2...
00:00:19.73 kernel: Buffers match.
00:00:19.93 kernel: Benchmark result (memset): 20000 calls in 202631 microseconds
00:00:19.95 kernel: Benchmark result (memset2): 20000 calls in 13686 microseconds
00:00:19.96 kernel: Calling memset (0xa414b, 0x841dfdca, 0x2f2e)
00:00:19.96 kernel: Calling memset2 (0x9c14b, 0x841dfdca, 0x2f2e)
00:00:19.97 kernel: Comparing results of memset and memset2...
00:00:19.97 kernel: Buffers match.
00:00:20.38 kernel: Benchmark result (memset): 20000 calls in 403030 microseconds
00:00:20.41 kernel: Benchmark result (memset2): 20000 calls in 27455 microseconds
00:00:20.42 kernel: Calling memset (0xa2a88, 0x1b4e9786, 0x39c0)
00:00:20.42 kernel: Calling memset2 (0x9aa88, 0x1b4e9786, 0x39c0)
00:00:20.43 kernel: Comparing results of memset and memset2...
00:00:20.43 kernel: Buffers match.
00:00:20.48 kernel: Benchmark result (memset): 20000 calls in 46673 microseconds
00:00:20.52 kernel: Benchmark result (memset2): 20000 calls in 32422 microseconds
00:00:20.52 kernel: Calling memset (0xa1de6, 0xbd67212c, 0x3118)
00:00:20.53 kernel: Calling memset2 (0x99de6, 0xbd67212c, 0x3118)
00:00:20.53 kernel: Comparing results of memset and memset2...
00:00:20.54 kernel: Buffers match.
00:00:20.96 kernel: Benchmark result (memset): 20000 calls in 419366 microseconds
00:00:21.00 kernel: Benchmark result (memset2): 20000 calls in 28788 microseconds
00:00:21.00 kernel: Calling memset (0xa3202, 0x5d7734ee, 0x3b69)
00:00:21.01 kernel: Calling memset2 (0x9b202, 0x5d7734ee, 0x3b69)
00:00:21.01 kernel: Comparing results of memset and memset2...
00:00:21.02 kernel: Buffers match.
00:00:21.53 kernel: Benchmark result (memset): 20000 calls in 507414 microseconds
00:00:21.57 kernel: Benchmark result (memset2): 20000 calls in 33590 microseconds
00:00:21.57 kernel: Calling memset (0xa43d4, 0x99064732, 0x30e0)
00:00:21.58 kernel: Calling memset2 (0x9c3d4, 0x99064732, 0x30e0)
00:00:21.58 kernel: Comparing results of memset and memset2...
00:00:21.59 kernel: Buffers match.
00:00:22.01 kernel: Benchmark result (memset): 20000 calls in 417500 microseconds
00:00:22.04 kernel: Benchmark result (memset2): 20000 calls in 27738 microseconds
00:00:22.04 kernel: Calling memset (0xa1a83, 0x37d5b05d, 0x1c40)
00:00:22.05 kernel: Calling memset2 (0x99a83, 0x37d5b05d, 0x1c40)
00:00:22.06 kernel: Comparing results of memset and memset2...
00:00:22.06 kernel: Buffers match.
00:00:22.31 kernel: Benchmark result (memset): 20000 calls in 241472 microseconds
00:00:22.33 kernel: Benchmark result (memset2): 20000 calls in 16687 microseconds
00:00:22.33 kernel: Calling memset (0xa0d93, 0xadc64db0, 0x1a55)
00:00:22.34 kernel: Calling memset2 (0x98d93, 0xadc64db0, 0x1a55)
00:00:22.34 kernel: Comparing results of memset and memset2...
00:00:22.35 kernel: Buffers match.
00:00:22.58 kernel: Benchmark result (memset): 20000 calls in 225103 microseconds
00:00:22.60 kernel: Benchmark result (memset2): 20000 calls in 15153 microseconds
00:00:22.60 kernel: Calling memset (0xa5a3a, 0x90c19579, 0x666)
00:00:22.61 kernel: Calling memset2 (0x9da3a, 0x90c19579, 0x666)
00:00:22.61 kernel: Comparing results of memset and memset2...
00:00:22.62 kernel: Buffers match.
00:00:22.68 kernel: Benchmark result (memset): 20000 calls in 54976 microseconds
00:00:22.68 kernel: Benchmark result (memset2): 20000 calls in 4000 microseconds
00:00:22.69 kernel: Calling memset (0xa66bf, 0x3800250b, 0x6ab)
00:00:22.69 kernel: Calling memset2 (0x9e6bf, 0x3800250b, 0x6ab)
00:00:22.70 kernel: Comparing results of memset and memset2...
00:00:22.71 kernel: Buffers match.
00:00:22.77 kernel: Benchmark result (memset): 20000 calls in 57277 microseconds
00:00:22.77 kernel: Benchmark result (memset2): 20000 calls in 4617 microseconds
00:00:22.78 kernel: Calling memset (0xa02e8, 0xdbc9ef33, 0x3cf8)
00:00:22.78 kernel: Calling memset2 (0x982e8, 0xdbc9ef33, 0x3cf8)
00:00:22.79 kernel: Comparing results of memset and memset2...
00:00:22.80 kernel: Buffers match.
00:00:22.85 kernel: Benchmark result (memset): 20000 calls in 49492 microseconds
00:00:22.89 kernel: Benchmark result (memset2): 20000 calls in 34073 microseconds
00:00:22.89 kernel: Calling memset (0xa6f83, 0x694f4032, 0x494)
00:00:22.90 kernel: Calling memset2 (0x9ef83, 0x694f4032, 0x494)
00:00:22.90 kernel: Comparing results of memset and memset2...
00:00:22.91 kernel: Buffers match.
00:00:22.95 kernel: Benchmark result (memset): 20000 calls in 39440 microseconds
00:00:22.96 kernel: Benchmark result (memset2): 20000 calls in 4918 microseconds
00:00:22.96 kernel: Calling memset (0xa6720, 0x1728dc04, 0x1bc)
00:00:22.97 kernel: Calling memset2 (0x9e720, 0x1728dc04, 0x1bc)
00:00:22.98 kernel: Comparing results of memset and memset2...
00:00:22.98 kernel: Buffers match.
00:00:22.99 kernel: Benchmark result (memset): 20000 calls in 1985 microseconds
00:00:22.99 kernel: Benchmark result (memset2): 20000 calls in 2101 microseconds
00:00:23.00 kernel: Calling memset (0xa08d2, 0x6d03189, 0x610b)
00:00:23.00 kernel: Calling memset2 (0x988d2, 0x6d03189, 0x610b)
00:00:23.01 kernel: Comparing results of memset and memset2...
00:00:23.02 kernel: Buffers match.
00:00:23.85 kernel: Benchmark result (memset): 20000 calls in 828597 microseconds
00:00:23.90 kernel: Benchmark result (memset2): 20000 calls in 53775 microseconds
00:00:23.91 kernel: Calling memset (0xa0e87, 0xf3415a3d, 0x3cfb)
00:00:23.91 kernel: Calling memset2 (0x98e87, 0xf3415a3d, 0x3cfb)
00:00:23.92 kernel: Comparing results of memset and memset2...
00:00:23.93 kernel: Buffers match.
00:00:24.45 kernel: Benchmark result (memset): 20000 calls in 520815 microseconds
00:00:24.49 kernel: Benchmark result (memset2): 20000 calls in 33990 microseconds
00:00:24.49 kernel: Calling memset (0xa1138, 0x39df9606, 0x4422)
00:00:24.50 kernel: Calling memset2 (0x99138, 0x39df9606, 0x4422)
00:00:24.50 kernel: Comparing results of memset and memset2...
00:00:24.51 kernel: Buffers match.
00:00:24.57 kernel: Benchmark result (memset): 20000 calls in 55010 microseconds
00:00:24.61 kernel: Benchmark result (memset2): 20000 calls in 38073 microseconds
00:00:24.61 kernel: Calling memset (0xa655b, 0xc0b2327f, 0x9f0)
00:00:24.62 kernel: Calling memset2 (0x9e55b, 0xc0b2327f, 0x9f0)
00:00:24.63 kernel: Comparing results of memset and memset2...
00:00:24.63 kernel: Buffers match.
00:00:24.72 kernel: Benchmark result (memset): 20000 calls in 85181 microseconds
00:00:24.73 kernel: Benchmark result (memset2): 20000 calls in 6252 microseconds
00:00:24.73 kernel: Calling memset (0xa3696, 0x5ddf561a, 0x3d39)
00:00:24.74 kernel: Calling memset2 (0x9b696, 0x5ddf561a, 0x3d39)
00:00:24.75 kernel: Comparing results of memset and memset2...
00:00:24.75 kernel: Buffers match.
00:00:25.28 kernel: Benchmark result (memset): 20000 calls in 522882 microseconds
00:00:25.32 kernel: Benchmark result (memset2): 20000 calls in 33890 microseconds
00:00:25.32 kernel: Calling memset (0xa101f, 0xbde00530, 0x1002)
00:00:25.33 kernel: Calling memset2 (0x9901f, 0xbde00530, 0x1002)
00:00:25.33 kernel: Comparing results of memset and memset2...
00:00:25.34 kernel: Buffers match.
00:00:25.48 kernel: Benchmark result (memset): 20000 calls in 136989 microseconds
00:00:25.49 kernel: Benchmark result (memset2): 20000 calls in 9235 microseconds
00:00:25.50 kernel: Calling memset (0xa0611, 0xfd2c057c, 0x4ba2)
00:00:25.50 kernel: Calling memset2 (0x98611, 0xfd2c057c, 0x4ba2)
00:00:25.51 kernel: Comparing results of memset and memset2...
00:00:25.51 kernel: Buffers match.
00:00:26.16 kernel: Benchmark result (memset): 20000 calls in 645867 microseconds
00:00:26.21 kernel: Benchmark result (memset2): 20000 calls in 42340 microseconds
00:00:26.21 kernel: Calling memset (0xa6113, 0xfb867d15, 0xaca)
00:00:26.22 kernel: Calling memset2 (0x9e113, 0xfb867d15, 0xaca)
00:00:26.22 kernel: Comparing results of memset and memset2...
00:00:26.23 kernel: Buffers match.
00:00:26.33 kernel: Benchmark result (memset): 20000 calls in 92449 microseconds
00:00:26.34 kernel: Benchmark result (memset2): 20000 calls in 7735 microseconds
00:00:26.34 kernel: Calling memset (0xa577d, 0xa1b0e171, 0xed)
00:00:26.35 kernel: Calling memset2 (0x9d77d, 0xa1b0e171, 0xed)
00:00:26.35 kernel: Comparing results of memset and memset2...
00:00:26.36 kernel: Buffers match.
00:00:26.37 kernel: Benchmark result (memset): 20000 calls in 8268 microseconds
00:00:26.37 kernel: Benchmark result (memset2): 20000 calls in 1067 microseconds
00:00:26.38 kernel: Calling memset (0xa0e3a, 0xb5113d7b, 0x25d8)
00:00:26.39 kernel: Calling memset2 (0x98e3a, 0xb5113d7b, 0x25d8)
00:00:26.39 kernel: Comparing results of memset and memset2...
00:00:26.40 kernel: Buffers match.
00:00:26.72 kernel: Benchmark result (memset): 20000 calls in 323351 microseconds
00:00:26.75 kernel: Benchmark result (memset2): 20000 calls in 21653 microseconds
00:00:26.75 kernel: Calling memset (0xa49fe, 0x31480676, 0x19c9)
00:00:26.76 kernel: Calling memset2 (0x9c9fe, 0x31480676, 0x19c9)
00:00:26.77 kernel: Comparing results of memset and memset2...
00:00:26.77 kernel: Buffers match.
00:00:27.00 kernel: Benchmark result (memset): 20000 calls in 220435 microseconds
00:00:27.01 kernel: Benchmark result (memset2): 20000 calls in 14485 microseconds
00:00:27.02 kernel: Calling memset (0xa4f54, 0x9147d653, 0x1dc7)
00:00:27.02 kernel: Calling memset2 (0x9cf54, 0x9147d653, 0x1dc7)
00:00:27.03 kernel: Comparing results of memset and memset2...
00:00:27.04 kernel: Buffers match.
00:00:27.29 kernel: Benchmark result (memset): 20000 calls in 254506 microseconds
00:00:27.32 kernel: Benchmark result (memset2): 20000 calls in 17770 microseconds
00:00:27.32 kernel: All tests completed. memset total time: 21979142 microseconds, memset2 total time: 1789771 microseconds
```