### PR TITLE
Small code comment correction (ARM_CONTROL register bit numbers)

### DIFF
--- a/boot/armstub/armstub8.S
+++ b/boot/armstub/armstub8.S
@@ -74,8 +74,8 @@
 _start:
 	/*
 	 * LOCAL_CONTROL:
-	 * Bit 9 clear: Increment by 1 (vs. 2).
-	 * Bit 8 clear: Timer source is 19.2MHz crystal (vs. APB).
+	 * Bit 8 clear: Increment by 1 (vs. 2).
+	 * Bit 7 clear: Timer source is 19.2MHz crystal (vs. APB).
 	 */
 	mov x0, LOCAL_CONTROL
 	str wzr, [x0]


### PR DESCRIPTION
This is just a minor doc fix. I've created an upstream PR too: https://github.com/raspberrypi/tools/pull/134

See https://datasheets.raspberrypi.com/bcm2711/bcm2711-peripherals.pdf page 93

The assumption here is that the PDF is correct and the code comments are wrong, but I guess it could be the other way around...
