### PR TITLE
Terminal reset and reverse handling fix

### DIFF
--- a/lib/terminal.cpp
+++ b/lib/terminal.cpp
@@ -813,9 +813,9 @@ void CTerminalDevice::SetStandoutMode (unsigned nMode)
 	switch (nMode)
 	{
 	case 0:
-	case 27:
 		m_bReverseAttribute = FALSE;
 		m_Color = m_pDisplay->GetColor (CDisplay::NormalColor);
+		m_BackgroundColor = m_pDisplay->GetColor (CDisplay::Black);
 		break;
 
 	case 1:
@@ -828,6 +828,10 @@ void CTerminalDevice::SetStandoutMode (unsigned nMode)
 
 	case 7:
 		m_bReverseAttribute = TRUE;
+		break;
+
+	case 27:
+		m_bReverseAttribute = FALSE;
 		break;
 
 	case 30:


### PR DESCRIPTION
I believe reset (ESC [0m) should also restore the background colour to default.
I've also separated ESC [27m from reset as I think that should only toggle the reversed flag.

