### PR TITLE
Support configurable encoder types in KY040 driver

### DIFF
--- a/addon/sensor/ky040.cpp
+++ b/addon/sensor/ky040.cpp
@@ -23,38 +23,27 @@
 static const unsigned SwitchDebounceDelayMillis	= 50;
 static const unsigned SwitchTickDelayMillis = 500;
 
-CKY040::TState CKY040::s_NextState[StateUnknown][2][2] =
+// Encoder direction lookup table
+// Indexed by 4-bit pattern: (oldCLK << 3) | (oldDT << 2) | (newCLK << 1) | (newDT << 0)
+// Returns: -1 for counter-clockwise, 0 for invalid/no-change, +1 for clockwise
+static const s8 s_EncoderDirection[16] = 
 {
-	// {{CLK=0/DT=0, CLK=0/DT=1}, {CLK=1/DT=0, CLK=1/DT=1}}
-
-	{{StateInvalid,    StateCWStart},      {StateCCWStart,    StateStart}},   // StateStart
-
-	{{StateCWBothLow,  StateCWStart},      {StateInvalid,     StateStart}},   // StateCWStart
-	{{StateCWBothLow,  StateInvalid},      {StateCWFirstHigh, StateInvalid}}, // StateCWBothLow
-	{{StateInvalid,    StateInvalid},      {StateCWFirstHigh, StateStart}},   // StateCWFirstHigh
-
-	{{StateCCWBothLow, StateInvalid},      {StateCCWStart,    StateStart}},   // StateCCWStart
-	{{StateCCWBothLow, StateCCWFirstHigh}, {StateInvalid,     StateInvalid}}, // StateCCWBothLow
-	{{StateInvalid,    StateCCWFirstHigh}, {StateInvalid,     StateStart}},   // StateCCWFirstHigh
-
-	{{StateInvalid,    StateInvalid},      {StateInvalid,     StateStart}}    // StateInvalid
-};
-
-CKY040::TEvent CKY040::s_Output[StateUnknown][2][2] =
-{
-	// {{CLK=0/DT=0, CLK=0/DT=1}, {CLK=1/DT=0, CLK=1/DT=1}}
-
-	{{EventUnknown, EventUnknown}, {EventUnknown, EventUnknown}},          // StateStart
-
-	{{EventUnknown, EventUnknown}, {EventUnknown, EventUnknown}},          // StateCWStart
-	{{EventUnknown, EventUnknown}, {EventUnknown, EventUnknown}},          // StateCWBothLow
-	{{EventUnknown, EventUnknown}, {EventUnknown, EventClockwise}},        // StateCWFirstHigh
-
-	{{EventUnknown, EventUnknown}, {EventUnknown, EventUnknown}},          // StateCCWStart
-	{{EventUnknown, EventUnknown}, {EventUnknown, EventUnknown}},          // StateCCWBothLow
-	{{EventUnknown, EventUnknown}, {EventUnknown, EventCounterclockwise}}, // StateCCWFirstHigh
-
-	{{EventUnknown, EventUnknown}, {EventUnknown, EventUnknown}}           // StateInvalid
+	 0,	// 0000: 00→00 no change
+	-1,	// 0001: 00→01 counter-clockwise
+	 1,	// 0010: 00→10 clockwise
+	 0,	// 0011: 00→11 invalid (both pins changed)
+	 1,	// 0100: 01→00 clockwise
+	 0,	// 0101: 01→01 no change
+	 0,	// 0110: 01→10 invalid (both pins changed)
+	-1,	// 0111: 01→11 counter-clockwise
+	-1,	// 1000: 10→00 counter-clockwise
+	 0,	// 1001: 10→01 invalid (both pins changed)
+	 0,	// 1010: 10→10 no change
+	 1,	// 1011: 10→11 clockwise
+	 0,	// 1100: 11→00 invalid (both pins changed)
+	 1,	// 1101: 11→01 clockwise
+	-1,	// 1110: 11→10 counter-clockwise
+	 0	// 1111: 11→11 no change
 };
 
 CKY040::TSwitchState CKY040::s_NextSwitchState[SwitchStateUnknown][SwitchEventUnknown] =
@@ -87,14 +76,18 @@ CKY040::TEvent CKY040::s_SwitchOutput[SwitchStateUnknown][SwitchEventUnknown] =
 	{EventUnknown, EventUnknown, EventUnknown}		// SwitchStateInvalid
 };
 
-CKY040::CKY040 (unsigned nCLKPin, unsigned nDTPin, unsigned nSWPin, CGPIOManager *pGPIOManager)
+CKY040::CKY040 (unsigned nCLKPin, unsigned nDTPin, unsigned nSWPin, 
+                CGPIOManager *pGPIOManager, unsigned nEncoderDetents)
 :	m_CLKPin (nCLKPin, GPIOModeInputPullUp, pGPIOManager),
 	m_DTPin (nDTPin, GPIOModeInputPullUp, pGPIOManager),
 	m_SWPin (nSWPin, GPIOModeInputPullUp, pGPIOManager),
 	m_bPollingMode (!pGPIOManager),
 	m_bInterruptConnected (FALSE),
 	m_pEventHandler (nullptr),
-	m_State (StateStart),
+	m_nEncoderDetents (nEncoderDetents),
+	m_nStepCounter (0),
+	m_nLastCLK (0),
+	m_nLastDT (0),
 	m_hDebounceTimer (0),
 	m_hTickTimer (0),
 	m_nLastSWLevel (HIGH),
@@ -102,6 +95,9 @@ CKY040::CKY040 (unsigned nCLKPin, unsigned nDTPin, unsigned nSWPin, CGPIOManager
 	m_SwitchState (SwitchStateStart),
 	m_nSwitchLastTicks (0)
 {
+	// Read initial encoder pin states to prevent spurious step detection on first interrupt
+	m_nLastCLK = m_CLKPin.Read ();
+	m_nLastDT = m_DTPin.Read ();
 }
 
 CKY040::~CKY040 (void)
@@ -251,13 +247,30 @@ void CKY040::EncoderInterruptHandler (void *pParam)
 	assert (nCLK <= 1);
 	assert (nDT <= 1);
 
-	assert (pThis->m_State < StateUnknown);
-	TEvent Event = s_Output[pThis->m_State][nCLK][nDT];
-	pThis->m_State = s_NextState[pThis->m_State][nCLK][nDT];
+	// Use lookup table to determine direction
+	// Build 4-bit index from old and new pin states
+	unsigned nIndex = (pThis->m_nLastCLK << 3) | (pThis->m_nLastDT << 2) | (nCLK << 1) | nDT;
+	s8 nDirection = s_EncoderDirection[nIndex];
+	
+	// Update step counter if we have a valid transition
+	if (nDirection != 0) {
+		pThis->m_nStepCounter += nDirection;
+	}
 
-	if (   Event != EventUnknown
-	    && pThis->m_pEventHandler)
-	{
+	pThis->m_nLastCLK = nCLK;	// Remember current CLK state for next interrupt
+	pThis->m_nLastDT = nDT;		// Remember current DT state for next interrupt
+
+	// Fire event when step count reaches threshold
+	TEvent Event = EventUnknown;
+	if (pThis->m_nStepCounter >= (s8)pThis->m_nEncoderDetents) {
+		Event = EventClockwise;
+		pThis->m_nStepCounter = 0;
+	} else if (pThis->m_nStepCounter <= -(s8)pThis->m_nEncoderDetents) {
+		Event = EventCounterclockwise;
+		pThis->m_nStepCounter = 0;
+	}
+
+	if (Event != EventUnknown && pThis->m_pEventHandler) {
 		(*pThis->m_pEventHandler) (Event, pThis->m_pEventParam);
 	}
 }

--- a/addon/sensor/ky040.h
+++ b/addon/sensor/ky040.h
@@ -52,7 +52,10 @@ public:
 	/// \param nDTPin GPIO pin number of data pin (encoder pin B)
 	/// \param nSWPin GPIO pin number of switch pin
 	/// \param pGPIOManager Pointer to GPIO manager object (0 enables polling mode)
-	CKY040 (unsigned nCLKPin, unsigned nDTPin, unsigned nSWPin, CGPIOManager *pGPIOManager = 0);
+	/// \param nEncoderDetents Detents per rotation: 1=Quarter, 2=Half, 4=Full step (default)
+	CKY040 (unsigned nCLKPin, unsigned nDTPin, unsigned nSWPin, 
+	        CGPIOManager *pGPIOManager = 0, 
+	        unsigned nEncoderDetents = 4);
 
 	~CKY040 (void);
 
@@ -72,19 +75,6 @@ public:
 	void Update (void);
 
 private:
-	enum TState
-	{
-		StateStart,
-		StateCWStart,
-		StateCWBothLow,
-		StateCWFirstHigh,
-		StateCCWStart,
-		StateCCWBothLow,
-		StateCCWFirstHigh,
-		StateInvalid,
-		StateUnknown
-	};
-
 	enum TSwitchState
 	{
 		SwitchStateStart,
@@ -128,10 +118,10 @@ private:
 	void *m_pEventParam;
 
 	// encoder
-	TState m_State;
-
-	static TState s_NextState[StateUnknown][2][2];
-	static TEvent s_Output[StateUnknown][2][2];
+	u8 m_nEncoderDetents;
+	s8 m_nStepCounter;
+	u8 m_nLastCLK;
+	u8 m_nLastDT;
 
 	// switch low level
 	TKernelTimerHandle m_hDebounceTimer;


### PR DESCRIPTION
### Summary
**This PR adds support for quarter-step and half-step rotary encoders to the KY040 driver, while maintaining backward compatibility with full-step encoders (default behavior).**

Different rotary encoder hardware uses different detent mechanisms. The existing implementation only worked correctly with full-step encoders, making it incompatible with other variants.

### Changes

* Added nEncoderDetents parameter to CKY040 constructor (values: 1, 2, or 4; default: 4 for full-step)
* Replaced complex state machine with simpler lookup table approach
* Added step counter that accumulates transitions until threshold is reached
* Events are fired only when |counter| >= detents, providing consistent behavior across encoder types
* Handles contact bounce gracefully (invalid transitions return 0 direction)

### Technical Details

The new implementation uses a 16-entry lookup table that maps all possible pin state transitions to rotation direction (-1, 0, or +1). The step counter accumulates these values, and when the threshold is reached, an event is fired. This approach is simpler and more robust than the previous state machine. Invalid transitions (both pins change at the same time) also result in 0 (= no step count).

This provides direction detection while tolerating the imperfect Gray code sequences that real-world encoders produce due to contact bounce or missed steps.

### Testing

Tested with a half step encoder on a minidexed build with a Raspberry Pi 3:
detents=2 results in the expected behaviour (each detent is registered once)
detents=1 results in two steps per detent
detents=4 results in the previous behaviour (only every second detent is registered).

It's also worth noting, that previously the encoder was only responding after a start state is reached. Now the Encoder reacts right after system start.

Memory impact: Adds ~ 4 bytes per encoder instanct