### PR TITLE
New project home of circle-stdlib

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This document gives some information for Circle users, who want to help developi
 
 If you encounter a problem or want a new feature in Circle, you can create a new issue [here](https://github.com/rsta2/circle/issues). Before you do so, please check, if the same issue has been created by another user yet. You can use the search function to accomplish this. Some basic known issues have been reported [here](doc/issues.txt). Please check them too.
 
-Please take a moment to think about, if your request is not related more to the [circle-stdlib project](https://github.com/smuehlst/circle-stdlib), if you are using it together with Circle. If so, please create your issue there.
+Please take a moment to think about, if your request is not related more to the [circle-stdlib project](https://codeberg.org/larchcone/circle-stdlib), if you are using it together with Circle. If so, please create your issue there.
 
 ## Pull Requests
 

--- a/doc/issues.txt
+++ b/doc/issues.txt
@@ -26,7 +26,7 @@ Known issues of Circle are:
 * sample/31-webclient does not work any more, because of the missing SSL/TLS
   support. SSL/TLS support for Circle is developed here:
 
-	https://github.com/smuehlst/circle-stdlib
+	https://codeberg.org/larchcone/circle-stdlib
 
 * Some modules in the addon/ subdirectory will not build with STDLIB_SUPPORT = 0.
 

--- a/doc/qemu.txt
+++ b/doc/qemu.txt
@@ -8,11 +8,11 @@ it provides USB and TCP/IP networking support. For running Circle applications
 with TCP/IP networking in QEMU is still a patch needed, which is provided in
 this repository (commit 62b39b2):
 
-	https://github.com/smuehlst/qemu
+	https://codeberg.org/larchcone/qemu
 
 To get and build the QEMU source code for Circle enter the following commands:
 
-	git clone https://github.com/smuehlst/qemu.git		# with patch
+	git clone https://codeberg.org/larchcone/qemu.git	# with patch
 	git clone https://gitlab.com/qemu-project/qemu.git	# or latest version
 
 	cd qemu

--- a/doc/stdlib-support.txt
+++ b/doc/stdlib-support.txt
@@ -14,7 +14,7 @@ Please note that Circle needs support from external projects to implement the
 options STDLIB_SUPPORT=2 and STDLIB_SUPPORT=3. This is mainly realized by the
 following project (a newlib port for Circle) by Stephan Muehlstrasser:
 
-	https://github.com/smuehlst/circle-stdlib
+	https://codeberg.org/larchcone/circle-stdlib
 
 Circle is included as a Git sub-module into this project, which provides a configure
 script and makefiles to build all required libraries (including the

--- a/sample/31-webclient/README
+++ b/sample/31-webclient/README
@@ -5,7 +5,7 @@ now, which is not supported by Circle itself. But there is SSL/TLS support in
 the circle-stdlib project of Stephan Muehlstrasser soon. If you are interested
 in this, have a look at:
 
-	https://github.com/smuehlst/circle-stdlib
+	https://codeberg.org/larchcone/circle-stdlib
 
 This sample has been ported to SSL/TLS support in the referenced project, but is
 retained here, because it shows how to communicate with HTTP servers.


### PR DESCRIPTION
The project home of circle-stdlib is now on Codeberg.

Updated all links related to circle-stdlib and qemu that were moved to Codeberg, except for historic entries in change logs.
