### PR TITLE
Add SSD1309 OLED display driver (I2C + SPI)

### DIFF
--- a/addon/display/Makefile
+++ b/addon/display/Makefile
@@ -5,7 +5,7 @@
 CIRCLEHOME = ../..
 
 OBJS	= hd44780device.o st7789display.o ili9341display.o ssd1306display.o \
-	  chardevice.o ssd1306device.o st7789device.o
+	  ssd1309display.o chardevice.o ssd1306device.o st7789device.o
 
 libdisplay.a: $(OBJS)
 	@echo "  AR    $@"

--- a/addon/display/sample/ssd1309/Makefile
+++ b/addon/display/sample/ssd1309/Makefile
@@ -1,0 +1,14 @@
+#
+# Makefile
+#
+
+CIRCLEHOME = ../../../..
+
+OBJS	= main.o kernel.o
+
+LIBS	= $(CIRCLEHOME)/addon/display/libdisplay.a \
+	  $(CIRCLEHOME)/lib/libcircle.a
+
+include $(CIRCLEHOME)/Rules.mk
+
+-include $(DEPS)

--- a/addon/display/sample/ssd1309/README
+++ b/addon/display/sample/ssd1309/README
@@ -1,0 +1,24 @@
+README
+
+This sample demonstrates the CSSD1309Display driver for SSD1309-controlled OLED
+displays using the I2C interface (graphics mode). The SSD1309 is similar to the
+SSD1306 but requires a mandatory hardware reset pin and uses an external VBAT
+supply (no internal charge pump).
+
+Before building you have to configure the program in kernel.h according to the
+hardware of your display. You have to set the I2C address (typically 0x3C or
+0x3D) and the GPIO number of the reset pin. The default configuration is:
+
+Display		Raspberry Pi	Comment
+		GPIO
+
+SDA	<--	SDA	2	I2C data
+SCL	<--	SCL	3	I2C clock
+RST	<--		25	Reset (active low, active pull required)
+VCC	<--	3.3V		Power supply
+GND	<-->	GND
+
+The sample program runs a series of graphics tests on the 128x64 display:
+clearing, filling, drawing lines and rectangles, diagonal lines, a checkerboard
+pattern, display on/off cycling, and a final center box. Progress is logged to
+the screen and serial port (115200 baud).

--- a/addon/display/sample/ssd1309/kernel.cpp
+++ b/addon/display/sample/ssd1309/kernel.cpp
@@ -1,0 +1,202 @@
+//
+// kernel.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2025  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "kernel.h"
+#include <circle/string.h>
+#include <circle/util.h>
+#include <circle/machineinfo.h>
+
+static const char FromKernel[] = "kernel";
+
+#define I2C_MASTER_DEVICE	(CMachineInfo::Get ()->GetDevice (DeviceI2CMaster))
+
+CKernel::CKernel (void)
+:	m_Screen (m_Options.GetWidth (), m_Options.GetHeight ()),
+	m_Timer (&m_Interrupt),
+	m_Logger (m_Options.GetLogLevel (), &m_Timer),
+	m_I2CMaster (I2C_MASTER_DEVICE),
+	m_Display (&m_I2CMaster, RESET_PIN, I2C_SLAVE_ADDRESS)
+{
+	m_ActLED.Blink (5);	// show we are alive
+}
+
+CKernel::~CKernel (void)
+{
+}
+
+boolean CKernel::Initialize (void)
+{
+	boolean bOK = TRUE;
+
+	if (bOK)
+	{
+		bOK = m_Screen.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_Serial.Initialize (115200);
+	}
+
+	if (bOK)
+	{
+		CDevice *pTarget = m_DeviceNameService.GetDevice (m_Options.GetLogDevice (), FALSE);
+		if (pTarget == 0)
+		{
+			pTarget = &m_Screen;
+		}
+
+		bOK = m_Logger.Initialize (pTarget);
+	}
+
+	if (bOK)
+	{
+		bOK = m_Interrupt.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_Timer.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_I2CMaster.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_Display.Initialize ();
+	}
+
+	return bOK;
+}
+
+TShutdownMode CKernel::Run (void)
+{
+	m_Logger.Write (FromKernel, LogNotice, "Compile time: " __DATE__ " " __TIME__);
+	m_Logger.Write (FromKernel, LogNotice, "SSD1309 I2C display test started");
+
+	// Test 1: Clear display (should be blank after init)
+	m_Logger.Write (FromKernel, LogNotice, "Test 1: Display cleared (should be blank)");
+	m_Display.Clear (0);
+	CTimer::SimpleMsDelay (2000);
+
+	// Test 2: Fill display white
+	m_Logger.Write (FromKernel, LogNotice, "Test 2: Fill display white");
+	m_Display.Clear (1);
+	CTimer::SimpleMsDelay (2000);
+
+	// Test 3: Clear again
+	m_Display.Clear (0);
+	CTimer::SimpleMsDelay (500);
+
+	// Test 4: Draw individual pixels - horizontal line at y=0
+	m_Logger.Write (FromKernel, LogNotice, "Test 3: Drawing horizontal line at y=0");
+	for (unsigned x = 0; x < 128; x++)
+	{
+		m_Display.SetPixel (x, 0, 1);
+	}
+	CTimer::SimpleMsDelay (1000);
+
+	// Test 5: Draw vertical line at x=0
+	m_Logger.Write (FromKernel, LogNotice, "Test 4: Drawing vertical line at x=0");
+	for (unsigned y = 0; y < 64; y++)
+	{
+		m_Display.SetPixel (0, y, 1);
+	}
+	CTimer::SimpleMsDelay (1000);
+
+	// Test 6: Draw border rectangle
+	m_Logger.Write (FromKernel, LogNotice, "Test 5: Drawing border rectangle");
+	m_Display.Clear (0);
+	for (unsigned x = 0; x < 128; x++)
+	{
+		m_Display.SetPixel (x, 0, 1);
+		m_Display.SetPixel (x, 63, 1);
+	}
+	for (unsigned y = 0; y < 64; y++)
+	{
+		m_Display.SetPixel (0, y, 1);
+		m_Display.SetPixel (127, y, 1);
+	}
+	CTimer::SimpleMsDelay (2000);
+
+	// Test 7: Draw diagonal lines
+	m_Logger.Write (FromKernel, LogNotice, "Test 6: Drawing diagonal lines");
+	m_Display.Clear (0);
+	for (unsigned i = 0; i < 64; i++)
+	{
+		m_Display.SetPixel (i * 2, i, 1);		// top-left to bottom-right
+		m_Display.SetPixel (127 - i * 2, i, 1);	// top-right to bottom-left
+	}
+	CTimer::SimpleMsDelay (2000);
+
+	// Test 8: Checkerboard pattern using SetArea
+	m_Logger.Write (FromKernel, LogNotice, "Test 7: Checkerboard pattern");
+	m_Display.Clear (0);
+	{
+		// Create a small 8x8 checkerboard tile
+		u8 TileData[8];	// 8 rows, 1 byte per row (8 pixels wide)
+		for (unsigned row = 0; row < 8; row++)
+		{
+			TileData[row] = (row % 2 == 0) ? 0xAA : 0x55;
+		}
+
+		// Tile it across the display
+		for (unsigned ty = 0; ty < 64; ty += 8)
+		{
+			for (unsigned tx = 0; tx < 128; tx += 8)
+			{
+				CDisplay::TArea Area;
+				Area.x1 = tx;
+				Area.y1 = ty;
+				Area.x2 = tx + 7;
+				Area.y2 = ty + 7;
+				m_Display.SetArea (Area, TileData);
+			}
+		}
+	}
+	CTimer::SimpleMsDelay (2000);
+
+	// Test 9: Display on/off cycle
+	m_Logger.Write (FromKernel, LogNotice, "Test 8: Display off/on cycle");
+	m_Display.Off ();
+	CTimer::SimpleMsDelay (1000);
+	m_Display.On ();
+	CTimer::SimpleMsDelay (1000);
+
+	// Test 10: Final - show all tests passed
+	m_Logger.Write (FromKernel, LogNotice, "All SSD1309 display tests completed!");
+
+	// Draw a filled center box as final visual confirmation
+	m_Display.Clear (0);
+	for (unsigned y = 20; y < 44; y++)
+	{
+		for (unsigned x = 40; x < 88; x++)
+		{
+			m_Display.SetPixel (x, y, 1);
+		}
+	}
+
+	m_Logger.Write (FromKernel, LogNotice,
+			"Center box drawn. Display should show a white rectangle.");
+
+	return ShutdownHalt;
+}

--- a/addon/display/sample/ssd1309/kernel.h
+++ b/addon/display/sample/ssd1309/kernel.h
@@ -1,0 +1,74 @@
+//
+// kernel.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2025  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _kernel_h
+#define _kernel_h
+
+#include <circle/actled.h>
+#include <circle/koptions.h>
+#include <circle/devicenameservice.h>
+#include <circle/screen.h>
+#include <circle/serial.h>
+#include <circle/exceptionhandler.h>
+#include <circle/interrupt.h>
+#include <circle/timer.h>
+#include <circle/logger.h>
+#include <circle/types.h>
+#include <circle/i2cmaster.h>
+#include <circle/machineinfo.h>
+#include <display/ssd1309display.h>
+
+enum TShutdownMode
+{
+	ShutdownNone,
+	ShutdownHalt,
+	ShutdownReboot
+};
+
+// I2C display configuration
+#define I2C_SLAVE_ADDRESS	0x3C		// or 0x3D
+#define RESET_PIN		25		// GPIO SoC number
+
+class CKernel
+{
+public:
+	CKernel (void);
+	~CKernel (void);
+
+	boolean Initialize (void);
+
+	TShutdownMode Run (void);
+
+private:
+	// do not change this order
+	CActLED			m_ActLED;
+	CKernelOptions		m_Options;
+	CDeviceNameService	m_DeviceNameService;
+	CScreenDevice		m_Screen;
+	CSerialDevice		m_Serial;
+	CExceptionHandler	m_ExceptionHandler;
+	CInterruptSystem	m_Interrupt;
+	CTimer			m_Timer;
+	CLogger			m_Logger;
+	CI2CMaster		m_I2CMaster;
+
+	CSSD1309Display		m_Display;
+};
+
+#endif

--- a/addon/display/sample/ssd1309/main.cpp
+++ b/addon/display/sample/ssd1309/main.cpp
@@ -1,0 +1,46 @@
+//
+// main.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2020  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "kernel.h"
+#include <circle/startup.h>
+
+int main (void)
+{
+	// cannot292 return292 292292
+	CKernel Kernel;
+	if (!Kernel.Initialize ())
+	{
+		halt ();
+		return EXIT_HALT;
+	}
+
+	TShutdownMode ShutdownMode = Kernel.Run ();
+
+	switch (ShutdownMode)
+	{
+	case ShutdownReboot:
+		reboot ();
+		return EXIT_REBOOT;
+
+	case ShutdownHalt:
+	default:
+		halt ();
+		return EXIT_HALT;
+	}
+}

--- a/addon/display/sampleconfig.h
+++ b/addon/display/sampleconfig.h
@@ -25,6 +25,7 @@
 #define DISPLAY_TYPE_ST7789	1
 #define DISPLAY_TYPE_ILI9341	2
 #define DISPLAY_TYPE_SSD1306	3
+#define DISPLAY_TYPE_SSD1309	4
 
 //// Configuration for ST7789-based SPI displays ///////////////////////////////
 
@@ -78,6 +79,28 @@
 
 #include <display/ili9341display.h>
 
+//// Configuration for SSD1309-based SPI displays //////////////////////////////
+
+#elif SPI_DISPLAY == DISPLAY_TYPE_SSD1309
+
+#define DISPLAY_ROTATION	0		// degrees; 0 or 180
+
+#define SPI_MASTER_DEVICE	0		// 0, 4, 5, 6 on Raspberry Pi 4;
+						// 0, 1, 3, 5 on Raspberry Pi 5; 0 otherwise
+#define SPI_CLOCK_SPEED		8000000		// Hz
+#define SPI_CPOL		0
+#define SPI_CPHA		0
+#define SPI_CHIP_SELECT		0		// 0 or 1
+
+#define DC_PIN			22		// GPIO SoC numbers (not header positions!)
+#define RESET_PIN		25		// mandatory for SSD1309
+
+#define DISPLAY_CLASS		CSSD1309Display
+#define DISPLAY_PARAMETERS	DC_PIN, RESET_PIN, SPI_CHIP_SELECT, \
+				SPI_CLOCK_SPEED, SPI_CPOL, SPI_CPHA
+
+#include <display/ssd1309display.h>
+
 //// Configuration for SSD1306-based I2C displays //////////////////////////////
 
 #elif I2C_DISPLAY == DISPLAY_TYPE_SSD1306
@@ -95,6 +118,22 @@
 #define DISPLAY_PARAMETERS	WIDTH, HEIGHT, I2C_SLAVE_ADDRESS, I2C_CLOCK_SPEED
 
 #include <display/ssd1306display.h>
+
+//// Configuration for SSD1309-based I2C displays //////////////////////////////
+
+#elif I2C_DISPLAY == DISPLAY_TYPE_SSD1309
+
+#define DISPLAY_ROTATION	0		// degrees; 0 or 180
+
+#define I2C_MASTER_DEVICE	(CMachineInfo::Get ()->GetDevice (DeviceI2CMaster))
+#define I2C_CLOCK_SPEED		0		// Hz; 0 for system default
+#define I2C_SLAVE_ADDRESS	0x3C		// or 0x3D
+#define RESET_PIN		25		// mandatory for SSD1309
+
+#define DISPLAY_CLASS		CSSD1309Display
+#define DISPLAY_PARAMETERS	RESET_PIN, I2C_SLAVE_ADDRESS, I2C_CLOCK_SPEED
+
+#include <display/ssd1309display.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/addon/display/ssd1309display.cpp
+++ b/addon/display/ssd1309display.cpp
@@ -1,0 +1,333 @@
+//
+// ssd1309display.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2025  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <display/ssd1309display.h>
+#include <circle/timer.h>
+#include <circle/util.h>
+#include <assert.h>
+
+// I2C prefix bytes
+#define I2C_DATA	0x40
+#define I2C_CMD		0x80
+
+// SSD1309 commands (register-compatible with SSD1306)
+enum TSSD1309Command : u8
+{
+	SetMemoryAddressingMode    = 0x20,
+	SetColumnAddress           = 0x21,
+	SetPageAddress             = 0x22,
+	SetStartLine               = 0x40,
+	SetContrast                = 0x81,
+	EntireDisplayOnResume      = 0xA4,
+	SetNormalDisplay           = 0xA6,
+	SetMultiplexRatio          = 0xA8,
+	SetDisplayOff              = 0xAE,
+	SetDisplayOn               = 0xAF,
+	SetDisplayOffset           = 0xD3,
+	SetDisplayClockDivideRatio = 0xD5,
+	SetPrechargePeriod         = 0xD9,
+	SetCOMPins                 = 0xDA,
+	SetVCOMHDeselectLevel      = 0xDB
+};
+
+CSSD1309Display::CSSD1309Display (CI2CMaster *pI2CMaster,
+				  unsigned nResetPin,
+				  u8 uchI2CAddress, unsigned nClockSpeed)
+:	CDisplay (I1),
+	m_bSPI (FALSE),
+	m_pI2CMaster (pI2CMaster),
+	m_uchI2CAddress (uchI2CAddress),
+	m_nClockSpeed (nClockSpeed),
+	m_pSPIMaster (nullptr),
+	m_nChipSelect (0),
+	m_nSPIClockSpeed (0),
+	m_nCPOL (0),
+	m_nCPHA (0),
+	m_nRotation (0)
+{
+	assert (pI2CMaster != nullptr);
+
+	m_ResetPin.AssignPin (nResetPin);
+	m_ResetPin.SetMode (GPIOModeOutput, FALSE);
+}
+
+CSSD1309Display::CSSD1309Display (CSPIMaster *pSPIMaster,
+				  unsigned nDCPin, unsigned nResetPin,
+				  unsigned nChipSelect, unsigned nClockSpeed,
+				  unsigned nCPOL, unsigned nCPHA)
+:	CDisplay (I1),
+	m_bSPI (TRUE),
+	m_pI2CMaster (nullptr),
+	m_uchI2CAddress (0),
+	m_nClockSpeed (0),
+	m_pSPIMaster (pSPIMaster),
+	m_nChipSelect (nChipSelect),
+	m_nSPIClockSpeed (nClockSpeed),
+	m_nCPOL (nCPOL),
+	m_nCPHA (nCPHA),
+	m_DCPin (nDCPin, GPIOModeOutput),
+	m_nRotation (0)
+{
+	assert (pSPIMaster != nullptr);
+
+	m_ResetPin.AssignPin (nResetPin);
+	m_ResetPin.SetMode (GPIOModeOutput, FALSE);
+}
+
+CSSD1309Display::~CSSD1309Display (void)
+{
+	Off ();
+}
+
+boolean CSSD1309Display::Initialize (void)
+{
+	// Hardware reset is mandatory for SSD1309
+	HardwareReset ();
+
+	const u8 nSegRemap   = m_nRotation == 180 ? 0xA0 : 0xA1;
+	const u8 nCOMScanDir = m_nRotation == 180 ? 0xC0 : 0xC8;
+
+	const u8 InitSequence[] =
+	{
+		SetDisplayOff,
+		SetDisplayClockDivideRatio,	0x80,		// Default value
+		SetMultiplexRatio,		0x3F,		// 64 MUX (height - 1)
+		SetDisplayOffset,		0x00,		// None
+		SetStartLine | 0x00,				// Set start line
+		SetMemoryAddressingMode,	0x00,		// 00 = horizontal
+		nSegRemap,
+		nCOMScanDir,					// COM output scan direction
+		SetCOMPins,			0x12,		// Alternate COM config
+		SetContrast,			0x7F,		// 00-FF, default to half
+		SetPrechargePeriod,		0xF1,		// SSD1309: phase 1=1, phase 2=15
+		SetVCOMHDeselectLevel,		0x34,		// SSD1309: ~0.78*Vcc
+		EntireDisplayOnResume,				// Resume to RAM content display
+		SetNormalDisplay,
+		SetDisplayOn
+	};
+
+	for (u8 nCommand : InitSequence)
+	{
+		if (!WriteCommand (nCommand))
+		{
+			return FALSE;
+		}
+	}
+
+	Clear ();
+
+	return TRUE;
+}
+
+void CSSD1309Display::On (void)
+{
+	WriteCommand (SetDisplayOn);
+}
+
+void CSSD1309Display::Off (void)
+{
+	WriteCommand (SetDisplayOff);
+}
+
+void CSSD1309Display::Clear (TRawColor nColor)
+{
+	size_t ulSize = Width * Height/8;
+
+	memset (m_Framebuffer, nColor ? 0xFF : 0x00, ulSize);
+
+	WriteMemory (0, Width-1, 0, Height/8-1, m_Framebuffer, ulSize);
+}
+
+void CSSD1309Display::SetPixel (unsigned nPosX, unsigned nPosY, TRawColor nColor)
+{
+	if (   nPosX >= Width
+	    || nPosY >= Height)
+	{
+		return;
+	}
+
+	u8 uchPage = nPosY / 8;
+	u8 uchMask = 1 << (nPosY & 7);
+
+	u8 *pBuffer = &m_Framebuffer[uchPage][nPosX];
+
+	if (nColor)
+	{
+		*pBuffer |= uchMask;
+	}
+	else
+	{
+		*pBuffer &= ~uchMask;
+	}
+
+	WriteMemory (nPosX, nPosX, uchPage, uchPage, pBuffer, sizeof *pBuffer);
+}
+
+void CSSD1309Display::SetArea (const TArea &rArea, const void *pPixels,
+			       TAreaCompletionRoutine *pRoutine, void *pParam)
+{
+	assert (rArea.x1 <= rArea.x2);
+	assert (rArea.y1 <= rArea.y2);
+	unsigned nWidth = rArea.x2 - rArea.x1 + 1;
+	unsigned nBytesWidth = (nWidth + 7) / 8;
+
+	// First transfer the pixel data into the framebuffer
+	assert (pPixels);
+	const u8 *pFrom = (const u8 *) pPixels;
+	for (unsigned y = rArea.y1; y <= rArea.y2; y++)
+	{
+		unsigned y0 = y - rArea.y1;
+
+		for (unsigned x = rArea.x1; x <= rArea.x2; x++)
+		{
+			unsigned x0 = x - rArea.x1;
+
+			if (pFrom[x0/8 + y0 * nBytesWidth] & (0x80 >> (x0 & 7)))
+			{
+				m_Framebuffer[y/8][x] |= 1 << (y & 7);
+			}
+			else
+			{
+				m_Framebuffer[y/8][x] &= ~(1 << (y & 7));
+			}
+		}
+	}
+
+	// Now transfer the updated area to the display
+	unsigned y1floor = rArea.y1 / 8 * 8;
+	unsigned y2ceil = (rArea.y2 + 7) / 8 * 8 - 1;
+	unsigned nHeight = y2ceil - y1floor + 1;
+
+	u8 Buffer[nWidth * nHeight/8];
+	for (unsigned y = y1floor; y <= y2ceil; y += 8)
+	{
+		unsigned y0 = y - y1floor;
+
+		for (unsigned x = rArea.x1; x <= rArea.x2; x++)
+		{
+			unsigned x0 = x - rArea.x1;
+
+			Buffer[x0 + y0/8 * nWidth] = m_Framebuffer[y/8][x];
+		}
+	}
+
+	WriteMemory (rArea.x1, rArea.x2, rArea.y1/8, rArea.y2/8, Buffer, sizeof Buffer);
+
+	if (pRoutine)
+	{
+		(*pRoutine) (pParam);
+	}
+}
+
+void CSSD1309Display::HardwareReset (void)
+{
+	m_ResetPin.Write (HIGH);
+	CTimer::SimpleMsDelay (10);
+	m_ResetPin.Write (LOW);
+	CTimer::SimpleMsDelay (10);
+	m_ResetPin.Write (HIGH);
+	CTimer::SimpleMsDelay (100);
+}
+
+boolean CSSD1309Display::WriteCommand (u8 uchCommand)
+{
+	if (m_bSPI)
+	{
+		assert (m_pSPIMaster);
+
+		m_DCPin.Write (LOW);
+
+		m_pSPIMaster->SetClock (m_nSPIClockSpeed);
+		m_pSPIMaster->SetMode (m_nCPOL, m_nCPHA);
+
+		return m_pSPIMaster->Write (m_nChipSelect, &uchCommand,
+					    sizeof uchCommand) == (int) sizeof uchCommand;
+	}
+	else
+	{
+		assert (m_pI2CMaster);
+
+		if (m_nClockSpeed)
+		{
+			m_pI2CMaster->SetClock (m_nClockSpeed);
+		}
+
+		u8 Cmd[] = {I2C_CMD, uchCommand};
+		return m_pI2CMaster->Write (m_uchI2CAddress, Cmd,
+					    sizeof Cmd) == (int) sizeof Cmd;
+	}
+}
+
+boolean CSSD1309Display::WriteMemory (unsigned nColumnStart, unsigned nColumnEnd,
+				      unsigned nPageStart, unsigned nPageEnd,
+				      const void *pData, size_t ulDataSize)
+{
+	if (m_bSPI)
+	{
+		assert (m_pSPIMaster);
+
+		// Send column/page address commands
+		m_DCPin.Write (LOW);
+
+		m_pSPIMaster->SetClock (m_nSPIClockSpeed);
+		m_pSPIMaster->SetMode (m_nCPOL, m_nCPHA);
+
+		u8 Cmds[] = {SetColumnAddress, (u8) nColumnStart, (u8) nColumnEnd,
+			     SetPageAddress,   (u8) nPageStart,   (u8) nPageEnd};
+		if (m_pSPIMaster->Write (m_nChipSelect, Cmds,
+					 sizeof Cmds) != (int) sizeof Cmds)
+		{
+			return FALSE;
+		}
+
+		// Send data
+		m_DCPin.Write (HIGH);
+
+		assert (pData);
+		return m_pSPIMaster->Write (m_nChipSelect, pData,
+					    ulDataSize) == (int) ulDataSize;
+	}
+	else
+	{
+		assert (m_pI2CMaster);
+
+		if (m_nClockSpeed)
+		{
+			m_pI2CMaster->SetClock (m_nClockSpeed);
+		}
+
+		u8 Cmds[] = {I2C_CMD, SetColumnAddress,
+			     I2C_CMD, (u8) nColumnStart, I2C_CMD, (u8) nColumnEnd,
+			     I2C_CMD, SetPageAddress,
+			     I2C_CMD, (u8) nPageStart,   I2C_CMD, (u8) nPageEnd};
+		if (m_pI2CMaster->Write (m_uchI2CAddress, Cmds,
+					 sizeof Cmds) != (int) sizeof Cmds)
+		{
+			return FALSE;
+		}
+
+		assert (pData);
+		u8 Buffer[1 + ulDataSize];
+		Buffer[0] = I2C_DATA;
+		memcpy (Buffer + 1, pData, ulDataSize);
+
+		return m_pI2CMaster->Write (m_uchI2CAddress, Buffer,
+					    sizeof Buffer) == (int) sizeof Buffer;
+	}
+}

--- a/addon/display/ssd1309display.h
+++ b/addon/display/ssd1309display.h
@@ -1,0 +1,133 @@
+//
+// ssd1309display.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2025  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _display_ssd1309display_h
+#define _display_ssd1309display_h
+
+#include <circle/display.h>
+#include <circle/i2cmaster.h>
+#include <circle/spimaster.h>
+#include <circle/gpiopin.h>
+#include <circle/types.h>
+
+class CSSD1309Display : public CDisplay	/// Driver for SSD1309-based OLED dot-matrix displays
+{
+public:
+	static const unsigned Width = 128;
+	static const unsigned Height = 64;
+
+public:
+	/// \brief Constructor for I2C interface
+	/// \param pI2CMaster I2C master to be used
+	/// \param nResetPin GPIO pin number for Reset pin (active low)
+	/// \param uchI2CAddress I2C slave address of the display controller (default 0x3C)
+	/// \param nClockSpeed I2C clock frequency in Hz (or 0 for system default)
+	CSSD1309Display (CI2CMaster *pI2CMaster,
+			 unsigned nResetPin,
+			 u8 uchI2CAddress = 0x3C, unsigned nClockSpeed = 0);
+
+	/// \brief Constructor for SPI interface
+	/// \param pSPIMaster Pointer to SPI master object
+	/// \param nDCPin GPIO pin number for DC pin
+	/// \param nResetPin GPIO pin number for Reset pin (active low)
+	/// \param nChipSelect SPI chip select (0 or 1, default 0)
+	/// \param nClockSpeed SPI clock frequency in Hz (default 8 MHz)
+	/// \param nCPOL SPI clock polarity (0 or 1, default 0)
+	/// \param nCPHA SPI clock phase (0 or 1, default 0)
+	CSSD1309Display (CSPIMaster *pSPIMaster,
+			 unsigned nDCPin, unsigned nResetPin,
+			 unsigned nChipSelect = 0, unsigned nClockSpeed = 8000000,
+			 unsigned nCPOL = 0, unsigned nCPHA = 0);
+
+	~CSSD1309Display (void);
+
+	/// \brief Set the global rotation of the display
+	/// \param nDegrees Rotation in degrees (0 or 180, default 0)
+	/// \note Must be set before calling Initialize().
+	void SetRotation (unsigned nDegrees)	{ m_nRotation = nDegrees; }
+	/// \return Rotation angle in degrees (0 or 180)
+	unsigned GetRotation (void) const	{ return m_nRotation; }
+
+	/// \return Operation successful?
+	boolean Initialize (void);
+
+	/// \return Display width in number of pixels
+	unsigned GetWidth (void) const		{ return Width; }
+	/// \return Display height in number of pixels
+	unsigned GetHeight (void) const		{ return Height; }
+	/// \return Number of bits per pixels
+	unsigned GetDepth (void) const		{ return 1; }
+
+	/// \brief Set display on
+	void On (void);
+	/// \brief Set display off
+	void Off (void);
+
+	/// \brief Clear entire display with color
+	/// \param nColor Raw color value (I1, default Black)
+	void Clear (TRawColor nColor = 0);
+
+	/// \brief Set a single pixel to color
+	/// \param nPosX X-position (0..width-1)
+	/// \param nPosY Y-postion (0..height-1)
+	/// \param nColor Raw color value (I1)
+	void SetPixel (unsigned nPosX, unsigned nPosY, TRawColor nColor);
+
+	/// \brief Set area (rectangle) on the display to the raw colors in pPixels
+	/// \param rArea Coordinates of the area (zero-based)
+	/// \param pPixels Pointer to array with raw color values (I1)
+	/// \param pRoutine Routine to be called on completion
+	/// \param pParam User parameter to be handed over to completion routine
+	void SetArea (const TArea &rArea, const void *pPixels,
+		      TAreaCompletionRoutine *pRoutine = nullptr,
+		      void *pParam = nullptr);
+
+private:
+	void HardwareReset (void);
+
+	boolean WriteCommand (u8 uchCommand);
+
+	boolean WriteMemory (unsigned nColumnStart, unsigned nColumnEnd,
+			     unsigned nPageStart, unsigned nPageEnd,
+			     const void *pData, size_t ulDataSize);
+
+private:
+	boolean m_bSPI;
+
+	// I2C specific
+	CI2CMaster *m_pI2CMaster;
+	u8 m_uchI2CAddress;
+	unsigned m_nClockSpeed;
+
+	// SPI specific
+	CSPIMaster *m_pSPIMaster;
+	unsigned m_nChipSelect;
+	unsigned m_nSPIClockSpeed;
+	unsigned m_nCPOL;
+	unsigned m_nCPHA;
+	CGPIOPin m_DCPin;
+
+	// Common
+	CGPIOPin m_ResetPin;
+	unsigned m_nRotation;
+
+	u8 m_Framebuffer[Height/8][Width];
+};
+
+#endif


### PR DESCRIPTION
Add CSSD1309Display graphics-mode driver for the SSD1309 128x64 OLED display controller. The SSD1309 is register-compatible with the SSD1306 but requires a mandatory hardware reset pin and uses external VBAT (no internal charge pump). Key initialization differences:
- No charge pump command
- Pre-charge period 0xF1 (vs SSD1306's 0x22)
- VCOMH deselect level 0x34 (vs SSD1306's 0x20)

The driver supports both I2C and SPI interfaces via separate constructors, following the dual-transport pattern used by CILI9341Display for SPI.

Includes:
- addon/display/ssd1309display.h and .cpp
- SPI and I2C configuration blocks in sampleconfig.h
- Sample program in addon/display/sample/ssd1309/

Tested on Raspberry Pi 3 (AArch64) with 2.4" 128x64 SSD1309 OLED via both I2C (0x3C) and SPI (8 MHz, CPOL/CPHA 0/0).
