### PR TITLE
Add MCP23017 I2C GPIO expander driver

### DIFF
--- a/addon/gpio/Makefile
+++ b/addon/gpio/Makefile
@@ -4,7 +4,7 @@
 
 CIRCLEHOME = ../..
 
-OBJS	= rtkgpio.o
+OBJS	= rtkgpio.o mcp23017.o
 
 libgpio.a: $(OBJS)
 	@echo "  AR    $@"

--- a/addon/gpio/mcp23017.cpp
+++ b/addon/gpio/mcp23017.cpp
@@ -1,0 +1,159 @@
+//
+// mcp23017.cpp
+//
+// Driver for MCP23017 I2C GPIO expander
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2025  T. Nelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "mcp23017.h"
+#include <assert.h>
+
+CMCP23017::CMCP23017 (CI2CMaster *pI2CMaster, u8 ucI2CAddress)
+:	m_pI2CMaster (pI2CMaster),
+	m_ucAddress (ucI2CAddress)
+{
+	assert (m_pI2CMaster != 0);
+	assert (m_ucAddress >= 0x20 && m_ucAddress <= 0x27);
+}
+
+CMCP23017::~CMCP23017 (void)
+{
+}
+
+boolean CMCP23017::Initialize (void)
+{
+	// Configure IOCON:
+	// BANK=0   (sequential register addresses)
+	// MIRROR=0 (separate INTA/INTB)
+	// SEQOP=0  (sequential operation enabled)
+	// DISSLW=0 (SDA slew rate control enabled)
+	// HAEN=0   (hardware address pins disabled)
+	// ODR=0    (active driver output for INT)
+	// INTPOL=0 (interrupt output active-low)
+	WriteRegister (MCP23017IOCon, 0x00);
+
+	// Set all pins as inputs by default
+	WriteRegister (MCP23017IODirA, 0xFF);
+	WriteRegister (MCP23017IODirB, 0xFF);
+
+	// Enable pull-ups on all pins
+	WriteRegister (MCP23017GPPUA, 0xFF);
+	WriteRegister (MCP23017GPPUB, 0xFF);
+
+	// Enable interrupts on all pins
+	WriteRegister (MCP23017GPIntEnA, 0xFF);
+	WriteRegister (MCP23017GPIntEnB, 0xFF);
+
+	// Compare against previous value (not DEFVAL)
+	WriteRegister (MCP23017IntConA, 0x00);
+	WriteRegister (MCP23017IntConB, 0x00);
+
+	// Clear any pending interrupts by reading capture registers
+	ReadRegister (MCP23017IntCapA);
+	ReadRegister (MCP23017IntCapB);
+
+	return TRUE;
+}
+
+void CMCP23017::SetDirectionA (u8 uchDirection)
+{
+	WriteRegister (MCP23017IODirA, uchDirection);
+}
+
+void CMCP23017::SetDirectionB (u8 uchDirection)
+{
+	WriteRegister (MCP23017IODirB, uchDirection);
+}
+
+void CMCP23017::SetPullUpA (u8 uchPullUp)
+{
+	WriteRegister (MCP23017GPPUA, uchPullUp);
+}
+
+void CMCP23017::SetPullUpB (u8 uchPullUp)
+{
+	WriteRegister (MCP23017GPPUB, uchPullUp);
+}
+
+void CMCP23017::EnableInterruptA (u8 uchPins)
+{
+	WriteRegister (MCP23017GPIntEnA, uchPins);
+}
+
+void CMCP23017::EnableInterruptB (u8 uchPins)
+{
+	WriteRegister (MCP23017GPIntEnB, uchPins);
+}
+
+u8 CMCP23017::ReadPortA (void)
+{
+	return ReadRegister (MCP23017GPIOA);
+}
+
+u8 CMCP23017::ReadPortB (void)
+{
+	return ReadRegister (MCP23017GPIOB);
+}
+
+u8 CMCP23017::ReadInterruptFlagA (void)
+{
+	return ReadRegister (MCP23017IntFA);
+}
+
+u8 CMCP23017::ReadInterruptFlagB (void)
+{
+	return ReadRegister (MCP23017IntFB);
+}
+
+u8 CMCP23017::ReadInterruptCaptureA (void)
+{
+	return ReadRegister (MCP23017IntCapA);
+}
+
+u8 CMCP23017::ReadInterruptCaptureB (void)
+{
+	return ReadRegister (MCP23017IntCapB);
+}
+
+void CMCP23017::WritePortA (u8 uchValue)
+{
+	WriteRegister (MCP23017OLATA, uchValue);
+}
+
+void CMCP23017::WritePortB (u8 uchValue)
+{
+	WriteRegister (MCP23017OLATB, uchValue);
+}
+
+void CMCP23017::WriteRegister (u8 uchRegister, u8 uchValue)
+{
+	assert (m_pI2CMaster != 0);
+
+	u8 Buffer[] = {uchRegister, uchValue};
+	m_pI2CMaster->Write (m_ucAddress, Buffer, sizeof Buffer);
+}
+
+u8 CMCP23017::ReadRegister (u8 uchRegister)
+{
+	assert (m_pI2CMaster != 0);
+
+	u8 Buffer[] = {uchRegister};
+	m_pI2CMaster->Write (m_ucAddress, Buffer, sizeof Buffer);
+	m_pI2CMaster->Read (m_ucAddress, Buffer, sizeof Buffer);
+
+	return Buffer[0];
+}

--- a/addon/gpio/mcp23017.h
+++ b/addon/gpio/mcp23017.h
@@ -1,0 +1,126 @@
+//
+// mcp23017.h
+//
+// Driver for MCP23017 I2C GPIO expander
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2025  T. Nelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _gpio_mcp23017_h
+#define _gpio_mcp23017_h
+
+#include <circle/i2cmaster.h>
+#include <circle/types.h>
+
+/// MCP23017 register addresses (BANK=0, sequential mode)
+enum TMCP23017Register
+{
+	MCP23017IODirA		= 0x00,		///< I/O direction A (1=input, 0=output)
+	MCP23017IODirB		= 0x01,		///< I/O direction B
+	MCP23017IPolA		= 0x02,		///< Input polarity A
+	MCP23017IPolB		= 0x03,		///< Input polarity B
+	MCP23017GPIntEnA	= 0x04,		///< Interrupt-on-change enable A
+	MCP23017GPIntEnB	= 0x05,		///< Interrupt-on-change enable B
+	MCP23017DefValA		= 0x06,		///< Default compare value A
+	MCP23017DefValB		= 0x07,		///< Default compare value B
+	MCP23017IntConA		= 0x08,		///< Interrupt control A
+	MCP23017IntConB		= 0x09,		///< Interrupt control B
+	MCP23017IOCon		= 0x0A,		///< Configuration register
+	MCP23017GPPUA		= 0x0C,		///< Pull-up resistor A
+	MCP23017GPPUB		= 0x0D,		///< Pull-up resistor B
+	MCP23017IntFA		= 0x0E,		///< Interrupt flag A
+	MCP23017IntFB		= 0x0F,		///< Interrupt flag B
+	MCP23017IntCapA		= 0x10,		///< Interrupt capture A
+	MCP23017IntCapB		= 0x11,		///< Interrupt capture B
+	MCP23017GPIOA		= 0x12,		///< Port register A
+	MCP23017GPIOB		= 0x13,		///< Port register B
+	MCP23017OLATA		= 0x14,		///< Output latch A
+	MCP23017OLATB		= 0x15		///< Output latch B
+};
+
+class CMCP23017		/// Driver for MCP23017 I2C 16-bit GPIO expander
+{
+public:
+	/// \param pI2CMaster Pointer to I2C master object
+	/// \param ucI2CAddress I2C slave address (0x20-0x27, default 0x20)
+	CMCP23017 (CI2CMaster *pI2CMaster, u8 ucI2CAddress = 0x20);
+
+	~CMCP23017 (void);
+
+	/// \brief Initialize the MCP23017
+	/// \return Operation successful?
+	/// \note Sets BANK=0, all pins as input with pull-ups and interrupts enabled
+	boolean Initialize (void);
+
+	/// \brief Set I/O direction for port A
+	/// \param uchDirection Bit mask (1=input, 0=output)
+	void SetDirectionA (u8 uchDirection);
+	/// \brief Set I/O direction for port B
+	/// \param uchDirection Bit mask (1=input, 0=output)
+	void SetDirectionB (u8 uchDirection);
+
+	/// \brief Enable internal pull-ups for port A
+	/// \param uchPullUp Bit mask (1=pull-up enabled)
+	void SetPullUpA (u8 uchPullUp);
+	/// \brief Enable internal pull-ups for port B
+	/// \param uchPullUp Bit mask (1=pull-up enabled)
+	void SetPullUpB (u8 uchPullUp);
+
+	/// \brief Enable interrupt-on-change for port A pins
+	/// \param uchPins Bit mask (1=interrupt enabled)
+	void EnableInterruptA (u8 uchPins);
+	/// \brief Enable interrupt-on-change for port B pins
+	/// \param uchPins Bit mask (1=interrupt enabled)
+	void EnableInterruptB (u8 uchPins);
+
+	/// \brief Read current state of port A
+	/// \return 8-bit port value
+	u8 ReadPortA (void);
+	/// \brief Read current state of port B
+	/// \return 8-bit port value
+	u8 ReadPortB (void);
+
+	/// \brief Read interrupt flag register for port A
+	/// \return Bit mask of pins that caused interrupt
+	u8 ReadInterruptFlagA (void);
+	/// \brief Read interrupt flag register for port B
+	/// \return Bit mask of pins that caused interrupt
+	u8 ReadInterruptFlagB (void);
+
+	/// \brief Read captured pin state at time of interrupt for port A
+	/// \return Port A value captured at interrupt time
+	u8 ReadInterruptCaptureA (void);
+	/// \brief Read captured pin state at time of interrupt for port B
+	/// \return Port B value captured at interrupt time
+	u8 ReadInterruptCaptureB (void);
+
+	/// \brief Write to port A output latches
+	/// \param uchValue 8-bit value to write
+	void WritePortA (u8 uchValue);
+	/// \brief Write to port B output latches
+	/// \param uchValue 8-bit value to write
+	void WritePortB (u8 uchValue);
+
+private:
+	void WriteRegister (u8 uchRegister, u8 uchValue);
+	u8 ReadRegister (u8 uchRegister);
+
+private:
+	CI2CMaster *m_pI2CMaster;
+	u8 m_ucAddress;
+};
+
+#endif

--- a/addon/gpio/sample/mcp23017/Makefile
+++ b/addon/gpio/sample/mcp23017/Makefile
@@ -1,0 +1,14 @@
+#
+# Makefile
+#
+
+CIRCLEHOME = ../../../..
+
+OBJS	= main.o kernel.o
+
+LIBS	= $(CIRCLEHOME)/addon/gpio/libgpio.a \
+	  $(CIRCLEHOME)/lib/libcircle.a
+
+include $(CIRCLEHOME)/Rules.mk
+
+-include $(DEPS)

--- a/addon/gpio/sample/mcp23017/README
+++ b/addon/gpio/sample/mcp23017/README
@@ -1,0 +1,25 @@
+README
+
+This sample demonstrates the CMCP23017 driver for the MCP23017 I2C 16-bit GPIO
+expander. The MCP23017 provides two 8-bit ports (A and B) with configurable
+direction, internal pull-ups, and interrupt-on-change capability.
+
+Before building you have to configure the program in kernel.h according to your
+hardware. You have to set the I2C address (0x20-0x27, depending on the A0-A2 pin
+strapping) and the GPIO numbers of the interrupt lines. The default configuration
+is:
+
+MCP23017	Raspberry Pi	Comment
+		GPIO
+
+SDA	<--	SDA	2	I2C data
+SCL	<--	SCL	3	I2C clock
+INTA	-->		16	Interrupt output port A (active low)
+INTB	-->		26	Interrupt output port B (active low)
+VCC	<--	3.3V		Power supply
+GND	<-->	GND
+
+The sample program reads the initial state of both ports, writes output patterns
+to port A, and then enters a 30-second polling loop. During polling it monitors
+the INTA/INTB lines and logs any pin state changes or interrupt events to the
+screen and serial port (115200 baud).

--- a/addon/gpio/sample/mcp23017/kernel.cpp
+++ b/addon/gpio/sample/mcp23017/kernel.cpp
@@ -1,0 +1,223 @@
+//
+// kernel.cpp
+//
+// MCP23017 GPIO expander test
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2025  T. Nelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include "kernel.h"
+#include <circle/string.h>
+#include <circle/util.h>
+#include <circle/machineinfo.h>
+
+static const char FromKernel[] = "kernel";
+
+#define I2C_MASTER_DEVICE	(CMachineInfo::Get ()->GetDevice (DeviceI2CMaster))
+
+CKernel::CKernel (void)
+:	m_Screen (m_Options.GetWidth (), m_Options.GetHeight ()),
+	m_Timer (&m_Interrupt),
+	m_Logger (m_Options.GetLogLevel (), &m_Timer),
+	m_I2CMaster (I2C_MASTER_DEVICE),
+	m_MCP23017 (&m_I2CMaster, MCP23017_I2C_ADDRESS),
+	m_IntAPin (INTA_PIN, GPIOModeInputPullUp),
+	m_IntBPin (INTB_PIN, GPIOModeInputPullUp)
+{
+	m_ActLED.Blink (5);
+}
+
+CKernel::~CKernel (void)
+{
+}
+
+boolean CKernel::Initialize (void)
+{
+	boolean bOK = TRUE;
+
+	if (bOK)
+	{
+		bOK = m_Screen.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_Serial.Initialize (115200);
+	}
+
+	if (bOK)
+	{
+		CDevice *pTarget = m_DeviceNameService.GetDevice (m_Options.GetLogDevice (), FALSE);
+		if (pTarget == 0)
+		{
+			pTarget = &m_Screen;
+		}
+
+		bOK = m_Logger.Initialize (pTarget);
+	}
+
+	if (bOK)
+	{
+		bOK = m_Interrupt.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_Timer.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_I2CMaster.Initialize ();
+	}
+
+	if (bOK)
+	{
+		bOK = m_MCP23017.Initialize ();
+	}
+
+	return bOK;
+}
+
+TShutdownMode CKernel::Run (void)
+{
+	m_Logger.Write (FromKernel, LogNotice, "Compile time: " __DATE__ " " __TIME__);
+	m_Logger.Write (FromKernel, LogNotice, "MCP23017 test started (I2C addr 0x%02X)",
+			MCP23017_I2C_ADDRESS);
+	m_Logger.Write (FromKernel, LogNotice, "INTA=GPIO%u  INTB=GPIO%u",
+			INTA_PIN, INTB_PIN);
+
+	// Test 1: Read initial port state
+	m_Logger.Write (FromKernel, LogNotice, "--- Test 1: Read initial port state ---");
+	u8 uchPortA = m_MCP23017.ReadPortA ();
+	u8 uchPortB = m_MCP23017.ReadPortB ();
+	m_Logger.Write (FromKernel, LogNotice,
+			"Port A: 0x%02X (%u%u%u%u%u%u%u%u)",
+			(unsigned) uchPortA,
+			(uchPortA >> 7) & 1, (uchPortA >> 6) & 1,
+			(uchPortA >> 5) & 1, (uchPortA >> 4) & 1,
+			(uchPortA >> 3) & 1, (uchPortA >> 2) & 1,
+			(uchPortA >> 1) & 1, (uchPortA >> 0) & 1);
+	m_Logger.Write (FromKernel, LogNotice,
+			"Port B: 0x%02X (%u%u%u%u%u%u%u%u)",
+			(unsigned) uchPortB,
+			(uchPortB >> 7) & 1, (uchPortB >> 6) & 1,
+			(uchPortB >> 5) & 1, (uchPortB >> 4) & 1,
+			(uchPortB >> 3) & 1, (uchPortB >> 2) & 1,
+			(uchPortB >> 1) & 1, (uchPortB >> 0) & 1);
+	CTimer::SimpleMsDelay (1000);
+
+	// Test 2: Configure port A as output, write pattern
+	m_Logger.Write (FromKernel, LogNotice, "--- Test 2: Port A output test ---");
+	m_MCP23017.SetDirectionA (0x00);	// All outputs
+
+	m_Logger.Write (FromKernel, LogNotice, "Writing 0xAA to port A...");
+	m_MCP23017.WritePortA (0xAA);
+	CTimer::SimpleMsDelay (1000);
+
+	m_Logger.Write (FromKernel, LogNotice, "Writing 0x55 to port A...");
+	m_MCP23017.WritePortA (0x55);
+	CTimer::SimpleMsDelay (1000);
+
+	m_Logger.Write (FromKernel, LogNotice, "Writing 0xFF to port A...");
+	m_MCP23017.WritePortA (0xFF);
+	CTimer::SimpleMsDelay (1000);
+
+	m_Logger.Write (FromKernel, LogNotice, "Writing 0x00 to port A...");
+	m_MCP23017.WritePortA (0x00);
+	CTimer::SimpleMsDelay (1000);
+
+	// Reset port A back to inputs
+	m_MCP23017.SetDirectionA (0xFF);
+	m_MCP23017.SetPullUpA (0xFF);
+
+	// Test 3: Polling loop — read ports and monitor interrupts
+	m_Logger.Write (FromKernel, LogNotice,
+			"--- Test 3: Polling (press buttons / toggle inputs) ---");
+	m_Logger.Write (FromKernel, LogNotice,
+			"Monitoring ports for 30 seconds...");
+
+	u8 uchPrevA = m_MCP23017.ReadPortA ();
+	u8 uchPrevB = m_MCP23017.ReadPortB ();
+
+	unsigned nStartTime = m_Timer.GetTime ();
+	unsigned nLastPrint = 0;
+
+	while (m_Timer.GetTime () - nStartTime < 30)
+	{
+		// Check interrupt pins
+		unsigned nIntA = m_IntAPin.Read ();
+		unsigned nIntB = m_IntBPin.Read ();
+
+		boolean bChanged = FALSE;
+
+		if (nIntA == LOW)
+		{
+			u8 uchFlag = m_MCP23017.ReadInterruptFlagA ();
+			u8 uchCap  = m_MCP23017.ReadInterruptCaptureA ();
+			m_Logger.Write (FromKernel, LogNotice,
+					"INTA! Flag=0x%02X Capture=0x%02X",
+					(unsigned) uchFlag, (unsigned) uchCap);
+			bChanged = TRUE;
+		}
+
+		if (nIntB == LOW)
+		{
+			u8 uchFlag = m_MCP23017.ReadInterruptFlagB ();
+			u8 uchCap  = m_MCP23017.ReadInterruptCaptureB ();
+			m_Logger.Write (FromKernel, LogNotice,
+					"INTB! Flag=0x%02X Capture=0x%02X",
+					(unsigned) uchFlag, (unsigned) uchCap);
+			bChanged = TRUE;
+		}
+
+		// Also poll port values directly
+		uchPortA = m_MCP23017.ReadPortA ();
+		uchPortB = m_MCP23017.ReadPortB ();
+
+		if (uchPortA != uchPrevA || uchPortB != uchPrevB)
+		{
+			m_Logger.Write (FromKernel, LogNotice,
+					"Port change: A=0x%02X B=0x%02X",
+					(unsigned) uchPortA, (unsigned) uchPortB);
+			uchPrevA = uchPortA;
+			uchPrevB = uchPortB;
+			bChanged = TRUE;
+		}
+
+		// Print periodic status every 5 seconds
+		unsigned nElapsed = m_Timer.GetTime () - nStartTime;
+		if (nElapsed >= nLastPrint + 5)
+		{
+			nLastPrint = nElapsed;
+			m_Logger.Write (FromKernel, LogNotice,
+					"[%us] A=0x%02X B=0x%02X INTA=%s INTB=%s",
+					nElapsed,
+					(unsigned) uchPortA, (unsigned) uchPortB,
+					nIntA == LOW ? "ACTIVE" : "idle",
+					nIntB == LOW ? "ACTIVE" : "idle");
+		}
+
+		if (!bChanged)
+		{
+			CTimer::SimpleMsDelay (10);
+		}
+	}
+
+	m_Logger.Write (FromKernel, LogNotice, "All MCP23017 tests completed!");
+
+	return ShutdownHalt;
+}

--- a/addon/gpio/sample/mcp23017/kernel.h
+++ b/addon/gpio/sample/mcp23017/kernel.h
@@ -1,0 +1,79 @@
+//
+// kernel.h
+//
+// MCP23017 GPIO expander test
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2025  T. Nelissen
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _kernel_h
+#define _kernel_h
+
+#include <circle/actled.h>
+#include <circle/koptions.h>
+#include <circle/devicenameservice.h>
+#include <circle/screen.h>
+#include <circle/serial.h>
+#include <circle/exceptionhandler.h>
+#include <circle/interrupt.h>
+#include <circle/timer.h>
+#include <circle/logger.h>
+#include <circle/i2cmaster.h>
+#include <circle/gpiopin.h>
+#include <circle/types.h>
+#include <gpio/mcp23017.h>
+
+enum TShutdownMode
+{
+	ShutdownNone,
+	ShutdownHalt,
+	ShutdownReboot
+};
+
+// MCP23017 configuration
+#define MCP23017_I2C_ADDRESS	0x21
+#define INTA_PIN		16		// GPIO16 (header pin 36)
+#define INTB_PIN		26		// GPIO26 (header pin 37)
+
+class CKernel
+{
+public:
+	CKernel (void);
+	~CKernel (void);
+
+	boolean Initialize (void);
+
+	TShutdownMode Run (void);
+
+private:
+	// do not change this order
+	CActLED			m_ActLED;
+	CKernelOptions		m_Options;
+	CDeviceNameService	m_DeviceNameService;
+	CScreenDevice		m_Screen;
+	CSerialDevice		m_Serial;
+	CExceptionHandler	m_ExceptionHandler;
+	CInterruptSystem	m_Interrupt;
+	CTimer			m_Timer;
+	CLogger			m_Logger;
+	CI2CMaster		m_I2CMaster;
+
+	CMCP23017		m_MCP23017;
+	CGPIOPin		m_IntAPin;
+	CGPIOPin		m_IntBPin;
+};
+
+#endif

--- a/addon/gpio/sample/mcp23017/main.cpp
+++ b/addon/gpio/sample/mcp23017/main.cpp
@@ -1,0 +1,29 @@
+//
+// main.cpp
+//
+#include "kernel.h"
+#include <circle/startup.h>
+
+int main (void)
+{
+	CKernel Kernel;
+	if (!Kernel.Initialize ())
+	{
+		halt ();
+		return EXIT_HALT;
+	}
+
+	TShutdownMode ShutdownMode = Kernel.Run ();
+
+	switch (ShutdownMode)
+	{
+	case ShutdownReboot:
+		reboot ();
+		return EXIT_REBOOT;
+
+	case ShutdownHalt:
+	default:
+		halt ();
+		return EXIT_HALT;
+	}
+}


### PR DESCRIPTION
Add CMCP23017 driver for the MCP23017 16-bit I2C GPIO expander to the addon/gpio directory. The MCP23017 provides two 8-bit ports (A and B) with configurable direction, internal pull-ups, and interrupt-on-change capability.

The driver exposes:
- Per-port direction and pull-up configuration
- Port read/write operations
- Interrupt enable, flag, and capture register access
- All registers defined as TMCP23017Register enum (BANK=0 mode)

Includes:
- addon/gpio/mcp23017.h and .cpp
- Sample program in addon/gpio/sample/mcp23017/

Tested on Raspberry Pi 3 (AArch64) with MCP23017 at address 0x21: port read/write and interrupt detection verified via INTA/INTB pins.

Closes rsta2/circle#647