### PR TITLE
Onyx patches: runtime keymap switching + MAX_TASKS=40

### DIFF
--- a/include/circle/input/keyboardbehaviour.h
+++ b/include/circle/input/keyboardbehaviour.h
@@ -69,6 +69,8 @@ public:
 
 	u8 GetLEDStatus (void) const;
 
+	CKeyMap *GetKeyMap (void)	{ return &m_KeyMap; }	// Zircon: runtime layout switch
+
 private:
 	void GenerateKeyEvent (u8 ucKeyCode);
 

--- a/include/circle/input/keymap.h
+++ b/include/circle/input/keymap.h
@@ -130,6 +130,10 @@ public:
 
 	u8 GetLEDStatus (void) const;
 
+	// Zircon: switch to another compiled-in country map at runtime ("US","UK","DE",
+	// "FR","ES","IT","DV"). Returns FALSE if the locale is unknown.
+	boolean LoadMap (const char *pLocale);
+
 private:
 	static const void *LookupDefaultMap (const char *pLocale);
 

--- a/include/circle/sysconfig.h
+++ b/include/circle/sysconfig.h
@@ -273,7 +273,8 @@
 // MAX_TASKS is the maximum number of tasks in the system.
 
 #ifndef MAX_TASKS
-#define MAX_TASKS		20
+#define MAX_TASKS		40		// Onyx: bumped from 20 -- net stack adds
+						// background tasks (net/DHCP/WPA + NTP/IRC)
 #endif
 
 // TASK_STACK_SIZE is the stack size for each task.

--- a/include/circle/usb/usbkeyboard.h
+++ b/include/circle/usb/usbkeyboard.h
@@ -62,6 +62,9 @@ public:
 	// works in cooked and raw mode
 	boolean SetLEDs (u8 ucStatus);		// must not be called in interrupt context
 
+	// Zircon: access the cooked-mode key map so the layout can be switched at runtime.
+	CKeyMap *GetKeyMap (void)	{ return m_Behaviour.GetKeyMap (); }
+
 private:
 	void ReportHandler (const u8 *pReport, unsigned nReportSize);
 

--- a/lib/input/keymap.cpp
+++ b/lib/input/keymap.cpp
@@ -156,6 +156,18 @@ CKeyMap::~CKeyMap (void)
 {
 }
 
+// Zircon: replace the active map with another compiled-in country map at runtime.
+boolean CKeyMap::LoadMap (const char *pLocale)
+{
+	const void *pMap = LookupDefaultMap (pLocale);
+	if (pMap == 0)
+	{
+		return FALSE;
+	}
+	memcpy (m_KeyMap, pMap, sizeof m_KeyMap);
+	return TRUE;
+}
+
 boolean CKeyMap::ClearTable (u8 nTable)
 {
 	if (nTable > K_CTRLTAB)


### PR DESCRIPTION
Local changes to Circle (vs upstream Step51, 6177984e) used by Onyx:
- GetKeyMap() accessors + CKeyMap::LoadMap(locale) so the keyboard layout can be switched at runtime (the keyb command / theme editor); stock Circle only sets it at construction.
- MAX_TASKS 20 -> 40: the network stack adds background tasks (net/DHCP/WPA + NTP/IRC).

When creating a Pull Request, please be sure to select the *develop* branch as base, where your PR should be merged!
