### PR TITLE
8bitdo xbox360 keyboard and gamepad support

### DIFF
--- a/include/circle/usb/usbgamepad8bitdo.h
+++ b/include/circle/usb/usbgamepad8bitdo.h
@@ -42,9 +42,6 @@ protected:
 	void ReportHandler (const u8 *pReport, unsigned nReportSize);
 
 	void DecodeReport (const u8 *pReportBuffer);
-
-private:
-	boolean m_bInputSeen;
 };
 
 #endif

--- a/include/circle/usb/usbgamepad8bitdo.h
+++ b/include/circle/usb/usbgamepad8bitdo.h
@@ -1,0 +1,50 @@
+//
+// usbgamepad8bitdo.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2026  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _circle_usb_usbgamepad8bitdo_h
+#define _circle_usb_usbgamepad8bitdo_h
+
+#include <circle/usb/usbgamepad.h>
+
+class CUSBGamePad8bitdoDevice : public CUSBGamePadDevice
+{
+public:
+	CUSBGamePad8bitdoDevice (CUSBFunction *pFunction);
+	~CUSBGamePad8bitdoDevice (void);
+
+	boolean Configure (void);
+
+	unsigned GetProperties (void)
+	{
+		return   GamePadPropertyIsKnown
+		       | GamePadPropertyHasRumble;
+	}
+
+	boolean SetRumbleMode (TGamePadRumbleMode Mode);
+
+protected:
+	void ReportHandler (const u8 *pReport, unsigned nReportSize);
+
+	void DecodeReport (const u8 *pReportBuffer);
+
+private:
+	boolean m_bInputSeen;
+};
+
+#endif

--- a/include/circle/usb/usbgamepad8bitdopro.h
+++ b/include/circle/usb/usbgamepad8bitdopro.h
@@ -1,0 +1,37 @@
+//
+// usbgamepad8bitdopro.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2026  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _circle_usb_usbgamepad8bitdopro_h
+#define _circle_usb_usbgamepad8bitdopro_h
+
+#include <circle/usb/usbgamepad8bitdo.h>
+
+class CUSBGamePad8BitDoProDevice : public CUSBGamePad8bitdoDevice
+{
+public:
+	CUSBGamePad8BitDoProDevice (CUSBFunction *pFunction);
+	~CUSBGamePad8BitDoProDevice (void);
+
+	boolean Configure (void);
+
+private:
+	boolean m_bInterfaceOK;
+};
+
+#endif

--- a/include/circle/usb/usbgamepad8bitdoxinput.h
+++ b/include/circle/usb/usbgamepad8bitdoxinput.h
@@ -1,0 +1,34 @@
+//
+// usbgamepad8bitdoxinput.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2026  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _circle_usb_usbgamepad8bitdoxinput_h
+#define _circle_usb_usbgamepad8bitdoxinput_h
+
+#include <circle/usb/usbgamepad8bitdo.h>
+
+class CUSBGamePad8BitDoXInputDevice : public CUSBGamePad8bitdoDevice
+{
+public:
+	CUSBGamePad8BitDoXInputDevice (CUSBFunction *pFunction);
+	~CUSBGamePad8BitDoXInputDevice (void);
+
+	boolean Configure (void);
+};
+
+#endif

--- a/include/circle/usb/usbgamepadxbox360pcwireless.h
+++ b/include/circle/usb/usbgamepadxbox360pcwireless.h
@@ -1,0 +1,54 @@
+//
+// usbgamepadxbox360pcwireless.h
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2026  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _circle_usb_usbgamepadxbox360pcwireless_h
+#define _circle_usb_usbgamepadxbox360pcwireless_h
+
+#include <circle/usb/usbgamepad.h>
+#include <circle/types.h>
+
+class CUSBGamePadXbox360PCWirelessDevice : public CUSBGamePadDevice
+{
+public:
+	CUSBGamePadXbox360PCWirelessDevice (CUSBFunction *pFunction);
+	~CUSBGamePadXbox360PCWirelessDevice (void);
+
+	boolean Configure (void);
+
+	unsigned GetProperties (void)
+	{
+		return   GamePadPropertyIsKnown
+		       | GamePadPropertyHasLED
+		       | GamePadPropertyHasRumble;
+	}
+
+	boolean SetLEDMode (TGamePadLEDMode Mode);
+	boolean SetRumbleMode (TGamePadRumbleMode Mode);
+
+private:
+	void ReportHandler (const u8 *pReport, unsigned nReportSize);
+	void DecodeReport (const u8 *pReport);
+	boolean SendPresenceInquiry (void);
+
+private:
+	boolean m_bInterfaceOK;
+	boolean m_bControllerPresent;
+};
+
+#endif

--- a/include/circle/usb/usbkeyboard.h
+++ b/include/circle/usb/usbkeyboard.h
@@ -62,9 +62,13 @@ public:
 	// works in cooked and raw mode
 	boolean SetLEDs (u8 ucStatus);		// must not be called in interrupt context
 
-private:
+
+protected:
+	boolean ConfigureKeyboard (unsigned nReportSize);
 	void ReportHandler (const u8 *pReport, unsigned nReportSize);
 
+
+private:
 	static boolean FindByte (const u8 *pBuffer, u8 ucByte, unsigned nLength);
 
 private:

--- a/include/circle/usb/usbkeyboard8bitdo.h
+++ b/include/circle/usb/usbkeyboard8bitdo.h
@@ -1,0 +1,22 @@
+//
+// usbkeyboard8bitdo.h
+//
+
+#ifndef _circle_usb_usbkeyboard8bitdo_h
+#define _circle_usb_usbkeyboard8bitdo_h
+
+#include <circle/usb/usbkeyboard.h>
+
+class CUSBKeyboard8BitDoDevice : public CUSBKeyboardDevice
+{
+public:
+	CUSBKeyboard8BitDoDevice (CUSBFunction *pFunction);
+	~CUSBKeyboard8BitDoDevice (void);
+
+	boolean Configure (void);
+
+protected:
+	void ReportHandler (const u8 *pReport, unsigned nReportSize);
+};
+
+#endif

--- a/include/circle/usb/usbkeyboard8bitdo.h
+++ b/include/circle/usb/usbkeyboard8bitdo.h
@@ -1,7 +1,22 @@
 //
 // usbkeyboard8bitdo.h
 //
-
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2026  R. Stange <rsta2@o2online.de>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 #ifndef _circle_usb_usbkeyboard8bitdo_h
 #define _circle_usb_usbkeyboard8bitdo_h
 

--- a/lib/usb/Makefile
+++ b/lib/usb/Makefile
@@ -28,7 +28,7 @@ OBJS	= lan7800.o smsc951x.o usbbluetooth.o usbcdcethernet.o usbfloppydevice.o \
 	  usbconfigparser.o usbdevice.o usbdevicefactory.o usbendpoint.o usbfunction.o \
 	  usbgamepad.o usbgamepadps3.o usbgamepadps4.o usbgamepadstandard.o usbgamepadswitchpro.o \
 	  usbgamepad8bitdo.o usbgamepad8bitdopro.o usbgamepad8bitdoxinput.o \
-	  usbgamepadxbox360.o usbgamepadxboxone.o usbhiddevice.o usbhostcontroller.o \
+	  usbgamepadxbox360.o usbgamepadxbox360pcwireless.o usbgamepadxboxone.o usbhiddevice.o usbhostcontroller.o \
 	  usbkeyboard.o usbkeyboard8bitdo.o usbmassdevice.o usbmidi.o usbmidihost.o usbmouse.o usbprinter.o usbrequest.o \
 	  usbstandardhub.o usbstring.o usbserial.o usbserialhost.o usbserialch341.o usbserialcp210x.o \
 	  usbserialpl2303.o usbserialft231x.o usbserialcdc.o usbtouchscreen.o dwhciregister.o

--- a/lib/usb/Makefile
+++ b/lib/usb/Makefile
@@ -28,7 +28,7 @@ OBJS	= lan7800.o smsc951x.o usbbluetooth.o usbcdcethernet.o usbfloppydevice.o \
 	  usbconfigparser.o usbdevice.o usbdevicefactory.o usbendpoint.o usbfunction.o \
 	  usbgamepad.o usbgamepadps3.o usbgamepadps4.o usbgamepadstandard.o usbgamepadswitchpro.o \
 	  usbgamepadxbox360.o usbgamepadxboxone.o usbhiddevice.o usbhostcontroller.o \
-	  usbkeyboard.o usbmassdevice.o usbmidi.o usbmidihost.o usbmouse.o usbprinter.o usbrequest.o \
+	  usbkeyboard.o usbkeyboard8bitdo.o usbmassdevice.o usbmidi.o usbmidihost.o usbmouse.o usbprinter.o usbrequest.o \
 	  usbstandardhub.o usbstring.o usbserial.o usbserialhost.o usbserialch341.o usbserialcp210x.o \
 	  usbserialpl2303.o usbserialft231x.o usbserialcdc.o usbtouchscreen.o dwhciregister.o
 

--- a/lib/usb/Makefile
+++ b/lib/usb/Makefile
@@ -27,6 +27,7 @@ include $(CIRCLEHOME)/Rules.mk
 OBJS	= lan7800.o smsc951x.o usbbluetooth.o usbcdcethernet.o usbfloppydevice.o \
 	  usbconfigparser.o usbdevice.o usbdevicefactory.o usbendpoint.o usbfunction.o \
 	  usbgamepad.o usbgamepadps3.o usbgamepadps4.o usbgamepadstandard.o usbgamepadswitchpro.o \
+	  usbgamepad8bitdo.o usbgamepad8bitdopro.o usbgamepad8bitdoxinput.o \
 	  usbgamepadxbox360.o usbgamepadxboxone.o usbhiddevice.o usbhostcontroller.o \
 	  usbkeyboard.o usbkeyboard8bitdo.o usbmassdevice.o usbmidi.o usbmidihost.o usbmouse.o usbprinter.o usbrequest.o \
 	  usbstandardhub.o usbstring.o usbserial.o usbserialhost.o usbserialch341.o usbserialcp210x.o \

--- a/lib/usb/usbdevicefactory.cpp
+++ b/lib/usb/usbdevicefactory.cpp
@@ -38,6 +38,7 @@
 #include <circle/usb/usbgamepad8bitdopro.h>
 #include <circle/usb/usbgamepad8bitdoxinput.h>
 #include <circle/usb/usbgamepadxbox360.h>
+#include <circle/usb/usbgamepadxbox360pcwireless.h>
 #include <circle/usb/usbgamepadxboxone.h>
 #include <circle/usb/usbgamepadswitchpro.h>
 #include <circle/usb/usbprinter.h>
@@ -149,6 +150,11 @@ CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pNam
 		 || pName->Compare ("ven45e-28f") == 0)
 	{
 		pResult = new CUSBGamePadXbox360Device (pParent);
+	}
+	else if (pName->Compare ("ven45e-719") == 0 	// Xbox 360 PC Wireless Gaming Receiver
+		 || pName->Compare ("ven45e-2a9") == 0)  	// Xbox 360 PC Wireless Gaming Receiver (Clone device)
+	{
+		pResult = new CUSBGamePadXbox360PCWirelessDevice (pParent);
 	}
 	else if (   pName->Compare ("ven45e-2d1") == 0		// XBox One Controller
 		 || pName->Compare ("ven45e-2dd") == 0		// XBox One Controller (FW 2015)

--- a/lib/usb/usbdevicefactory.cpp
+++ b/lib/usb/usbdevicefactory.cpp
@@ -35,6 +35,8 @@
 #include <circle/usb/usbgamepadstandard.h>
 #include <circle/usb/usbgamepadps3.h>
 #include <circle/usb/usbgamepadps4.h>
+#include <circle/usb/usbgamepad8bitdopro.h>
+#include <circle/usb/usbgamepad8bitdoxinput.h>
 #include <circle/usb/usbgamepadxbox360.h>
 #include <circle/usb/usbgamepadxboxone.h>
 #include <circle/usb/usbgamepadswitchpro.h>
@@ -134,6 +136,14 @@ CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pNam
 		 || pName->Compare ("ven54c-9cc") == 0)
 	{
 		pResult = new CUSBGamePadPS4Device (pParent);
+	}
+	else if (pName->Compare ("ven2dc8-310b") == 0) // 8BitDo Pro 3 Bluetooth Gamepad, 8BitDo Ultimate 2.4G Controller, etc
+	{
+		pResult = new CUSBGamePad8BitDoProDevice(pParent);
+	}
+	else if (pName->Compare ("ven2dc8-3106") == 0) // 8BitDo Ultimate C 2.4G, 8BitDo USB Wireless Adapter 2, etc
+	{
+		pResult = new CUSBGamePad8BitDoXInputDevice (pParent);
 	}
 	else if (   pName->Compare ("ven45e-28e") == 0
 		 || pName->Compare ("ven45e-28f") == 0)

--- a/lib/usb/usbdevicefactory.cpp
+++ b/lib/usb/usbdevicefactory.cpp
@@ -30,6 +30,7 @@
 #include <circle/usb/usbmassdevice.h>
 #include <circle/usb/usbfloppydevice.h>
 #include <circle/usb/usbkeyboard.h>
+#include <circle/usb/usbkeyboard8bitdo.h>
 #include <circle/usb/usbmouse.h>
 #include <circle/usb/usbgamepadstandard.h>
 #include <circle/usb/usbgamepadps3.h>
@@ -91,7 +92,12 @@ CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pNam
 		CString *pVendor = pParent->GetDevice ()->GetName (DeviceNameVendor);
 		assert (pVendor != 0);
 
-		if (pVendor->Compare ("ven3f0-1198") != 0)	// HP USB 1000dpi Laser Mouse
+		if (   pVendor->Compare ("ven2dc8-5200") == 0
+		    || pVendor->Compare ("ven2dc8-5201") == 0)
+		{
+			pResult = new CUSBKeyboard8BitDoDevice (pParent);
+		}
+		else if (pVendor->Compare ("ven3f0-1198") != 0)	// HP USB 1000dpi Laser Mouse
 		{
 			pResult = new CUSBKeyboardDevice (pParent);
 		}

--- a/lib/usb/usbdevicefactory.cpp
+++ b/lib/usb/usbdevicefactory.cpp
@@ -155,6 +155,12 @@ CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pNam
 	{
 		pResult = new CUSBGamePad8BitDoXInputDevice (pParent);
 	}
+	else if (	pName->Compare ("ven2dc8-3107") == 0
+		 || pName->Compare ("ven2dc8-3109") == 0
+		 || pName->Compare ("ven2dc8-3016") == 0)	// 8BitDo idle receiver
+	{
+		pResult = new CUSBFunction (pParent);
+	}
 	else if (   pName->Compare ("ven45e-28e") == 0
 		 || pName->Compare ("ven45e-28f") == 0)
 	{

--- a/lib/usb/usbdevicefactory.cpp
+++ b/lib/usb/usbdevicefactory.cpp
@@ -96,7 +96,7 @@ CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pNam
 		assert (pVendor != 0);
 
 		if (   pVendor->Compare ("ven2dc8-5200") == 0
-		    || pVendor->Compare ("ven2dc8-5201") == 0)
+		    || pVendor->Compare ("ven2dc8-5201") == 0)  // 8bitDo Retro Keyboard
 		{
 			pResult = new CUSBKeyboard8BitDoDevice (pParent);
 		}
@@ -111,7 +111,16 @@ CUSBFunction *CUSBDeviceFactory::GetDevice (CUSBFunction *pParent, CString *pNam
 #ifndef EXCLUDE_USB_MOUSE
 	else if (pName->Compare ("int3-1-2") == 0)
 	{
-		pResult = new CUSBMouseDevice (pParent);
+		CString *pVendor = pParent->GetDevice ()->GetName (DeviceNameVendor);
+		assert (pVendor != 0);
+
+		if (   pVendor->Compare ("ven2dc8-5200") != 0
+		    && pVendor->Compare ("ven2dc8-5201") != 0) // 8bitDo Retro Keyboard
+		{
+			pResult = new CUSBMouseDevice (pParent);
+		}
+
+		delete pVendor;
 	}
 #endif
 	else if (   pName->Compare ("int3-0-0") == 0

--- a/lib/usb/usbgamepad8bitdo.cpp
+++ b/lib/usb/usbgamepad8bitdo.cpp
@@ -1,0 +1,212 @@
+//
+// usbgamepad8bitdo.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2026  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <circle/usb/usbgamepad8bitdo.h>
+#include <circle/logger.h>
+#include <circle/macros.h>
+#include <circle/debug.h>
+#include <assert.h>
+#include <string.h>
+
+static const char FromUSBPad8BitDo[] = "usbpad8bitdo";
+
+struct T8BitDoReport
+{
+	u16	Header;
+#define REPORT_HEADER			0x1400
+
+	u16	Buttons;
+#define REPORT_BUTTONS			16
+
+#define REPORT_ANALOG_BUTTONS		2
+	u8	AnalogButton[REPORT_ANALOG_BUTTONS];
+#define REPORT_ANALOG_BUTTON_MINIMUM	0
+#define REPORT_ANALOG_BUTTON_THRESHOLD	128
+#define REPORT_ANALOG_BUTTON_MAXIMUM	255
+
+#define REPORT_AXES			4
+	s16	Axes[REPORT_AXES];
+#define REPORT_AXES_MINIMUM		(-32768)
+#define REPORT_AXES_MAXIMUM		32767
+}
+PACKED;
+
+#define REPORT_DATA_SIZE	sizeof (T8BitDoReport)
+// 8BitDo input reports contain 14 bytes of controller state followed by six
+// reserved bytes. The interrupt endpoint has a 32-byte maximum packet size,
+// so the host buffer must be large enough for the complete USB packet.
+#define REPORT_SIZE_8BITDO	32 
+
+CUSBGamePad8bitdoDevice::CUSBGamePad8bitdoDevice (CUSBFunction *pFunction)
+: CUSBGamePadDevice (pFunction)
+{
+	m_bInputSeen = FALSE;
+}
+
+CUSBGamePad8bitdoDevice::~CUSBGamePad8bitdoDevice (void)
+{
+}
+
+boolean CUSBGamePad8bitdoDevice::Configure (void)
+{
+	m_usReportSize = REPORT_SIZE_8BITDO;
+
+	if (!CUSBGamePadDevice::Configure ())
+	{
+		CLogger::Get ()->Write (FromUSBPad8BitDo, LogError, "Cannot configure gamepad device");
+
+		return FALSE;
+	}
+
+	m_State.nbuttons = GAMEPAD_BUTTONS_STANDARD;
+	m_State.naxes = REPORT_AXES+REPORT_ANALOG_BUTTONS;
+	for (unsigned i = 0; i < REPORT_AXES; i++)
+	{
+		m_State.axes[i].minimum = GAMEPAD_AXIS_DEFAULT_MINIMUM;
+		m_State.axes[i].maximum = GAMEPAD_AXIS_DEFAULT_MAXIMUM;
+	}
+	for (unsigned i = 0; i < REPORT_ANALOG_BUTTONS; i++)
+	{
+		m_State.axes[REPORT_AXES+i].minimum = REPORT_ANALOG_BUTTON_MINIMUM;
+		m_State.axes[REPORT_AXES+i].maximum = REPORT_ANALOG_BUTTON_MAXIMUM;
+	}
+	m_State.nhats = 0;
+
+	return TRUE;
+}
+
+void CUSBGamePad8bitdoDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)
+{
+	if (   pReport != 0
+	    && nReportSize >= REPORT_DATA_SIZE
+	    && pReport[0] == (REPORT_HEADER & 0xFF)
+	    && pReport[1] == (REPORT_HEADER >> 8)
+		&& m_pStatusHandler != 0)
+	{
+		//debug_hexdump (pReport, m_usReportSize, FromUSBPad8BitDo);
+
+		DecodeReport (pReport);
+
+		(*m_pStatusHandler) (m_nDeviceNumber-1, &m_State);
+	}
+}
+
+void CUSBGamePad8bitdoDevice::DecodeReport (const u8 *pReportBuffer)
+{
+	const T8BitDoReport *pReport = reinterpret_cast<const T8BitDoReport *> (pReportBuffer);
+	assert (pReport != 0);
+	assert (pReport->Header == REPORT_HEADER);
+
+	static const u32 ButtonMap[] =
+	{
+		GamePadButtonUp,
+		GamePadButtonDown,
+		GamePadButtonLeft,
+		GamePadButtonRight,
+		GamePadButtonStart,
+		GamePadButtonBack,
+		GamePadButtonL3,
+		GamePadButtonR3,
+		GamePadButtonLB,
+		GamePadButtonRB,
+		GamePadButtonXbox,
+		0,
+		GamePadButtonA,
+		GamePadButtonB,
+		GamePadButtonX,
+		GamePadButtonY
+	};
+
+	u32 nButtons = pReport->Buttons;
+	m_State.buttons = 0;
+	for (unsigned i = 0; i < REPORT_BUTTONS; i++)
+	{
+		if (nButtons & 1)
+		{
+			m_State.buttons |= ButtonMap[i];
+		}
+
+		nButtons >>= 1;
+	}
+
+	static const unsigned AxisMap[] =
+	{
+		GamePadAxisLeftX,
+		GamePadAxisLeftY,
+		GamePadAxisRightX,
+		GamePadAxisRightY,
+		GamePadAxisButtonLT,
+		GamePadAxisButtonRT
+	};
+
+	for (unsigned i = 0; i < REPORT_AXES; i++)
+	{
+		int nValue = pReport->Axes[i];
+
+		// remap axis value to default range [0, 255]
+		nValue = (unsigned) (nValue - REPORT_AXES_MINIMUM) >> 8;
+
+		unsigned nAxis = AxisMap[i];
+		if (   nAxis == GamePadAxisLeftY
+		    || nAxis == GamePadAxisRightY)	// Y-axes have to be reversed
+		{
+			nValue = GAMEPAD_AXIS_DEFAULT_MAXIMUM - nValue;
+		}
+
+		m_State.axes[nAxis].value = nValue;
+	}
+
+	for (unsigned i = 0; i < REPORT_ANALOG_BUTTONS; i++)
+	{
+		m_State.axes[AxisMap[REPORT_AXES+i]].value = pReport->AnalogButton[i];
+
+		if (pReport->AnalogButton[i] >= REPORT_ANALOG_BUTTON_THRESHOLD)
+		{
+			m_State.buttons |= GamePadButtonLT << i;
+		}
+	}
+}
+
+boolean CUSBGamePad8bitdoDevice::SetRumbleMode (TGamePadRumbleMode Mode)
+{
+	DMA_BUFFER (u8, Command, 8);
+	memset (Command, 0, sizeof Command);
+	Command[1] = 0x08;
+
+	switch (Mode)
+	{
+	case GamePadRumbleModeOff:
+		break;
+
+	case GamePadRumbleModeLow:
+		Command[4] = 0xFF;
+		break;
+
+	case GamePadRumbleModeHigh:
+		Command[3] = 0xFF;
+		break;
+
+	default:
+		assert (0);
+		return FALSE;
+	}
+
+	return SendToEndpointOut (Command, sizeof Command);
+}
+

--- a/lib/usb/usbgamepad8bitdo.cpp
+++ b/lib/usb/usbgamepad8bitdo.cpp
@@ -56,7 +56,6 @@ PACKED;
 CUSBGamePad8bitdoDevice::CUSBGamePad8bitdoDevice (CUSBFunction *pFunction)
 : CUSBGamePadDevice (pFunction)
 {
-	m_bInputSeen = FALSE;
 }
 
 CUSBGamePad8bitdoDevice::~CUSBGamePad8bitdoDevice (void)

--- a/lib/usb/usbgamepad8bitdopro.cpp
+++ b/lib/usb/usbgamepad8bitdopro.cpp
@@ -1,0 +1,74 @@
+//
+// usbgamepad8bitdopro.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2026  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <circle/usb/usbgamepad8bitdopro.h>
+#include <circle/usb/usbhostcontroller.h>
+#include <circle/logger.h>
+#include <circle/macros.h>
+
+static const char FromUSBPad8BitDoPro[] = "usbpad8bitdopro";
+
+CUSBGamePad8BitDoProDevice::CUSBGamePad8BitDoProDevice (CUSBFunction *pFunction)
+: CUSBGamePad8bitdoDevice (pFunction),
+	m_bInterfaceOK (SelectInterfaceByClass (0xFF, 0x5D, 0x01, 1))
+{
+}
+
+CUSBGamePad8BitDoProDevice::~CUSBGamePad8BitDoProDevice (void)
+{
+}
+
+boolean CUSBGamePad8BitDoProDevice::Configure (void)
+{
+	if (!m_bInterfaceOK)
+	{
+		ConfigurationError (FromUSBPad8BitDoPro);
+
+		return FALSE;
+	}
+
+	if (!CUSBGamePad8bitdoDevice::Configure ())
+	{
+		return FALSE;
+	}
+
+	// Vendor specific command to initialize the receiver 
+    DMA_BUFFER (u8, Command, 3) = {0x01, 0x03, 0x02};
+	if (!SendToEndpointOut (Command, 3))
+	{
+		CLogger::Get ()->Write (FromUSBPad8BitDoPro, LogError, 
+                                "Cannot initialize receiver");
+
+		return FALSE;
+	}
+
+	DMA_BUFFER (u8, Response, 20);
+	int nResult = GetHost ()->ControlMessage (
+		GetEndpoint0 (), REQUEST_IN | REQUEST_VENDOR | REQUEST_TO_INTERFACE,
+		1, 0x0100, GetInterfaceNumber (), Response, 20);
+	if (nResult != 20)
+	{
+		CLogger::Get ()->Write (FromUSBPad8BitDoPro, LogError,
+					            "Cannot read receiver state (%d byte(s))", nResult);
+
+		return FALSE;
+	}
+
+	return StartRequest ();
+}

--- a/lib/usb/usbgamepad8bitdoxinput.cpp
+++ b/lib/usb/usbgamepad8bitdoxinput.cpp
@@ -18,6 +18,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 #include <circle/usb/usbgamepad8bitdoxinput.h>
+#include <circle/usb/usbdevice.h>
 
 static const char FromUSBPad8BitDoXInput[] = "usbpad8bitdoxinput";
 
@@ -44,12 +45,25 @@ boolean CUSBGamePad8BitDoXInputDevice::Configure (void)
 		return FALSE;
 	}
 
+	const TUSBDeviceDescriptor *pDeviceDesc = GetDevice ()->GetDeviceDescriptor ();
+	assert (pDeviceDesc != 0);
+	if (pDeviceDesc->bcdDevice == 0x0100)
+	{
+		// Receiver firmware 1.00 is a bootstrap personality. After this init
+		// command it disconnects and re-enumerates as the idle 3107 receiver,
+		// or as runtime 3106 once a controller connects. Do not start interrupt
+		// polling or issue the runtime status request before that transition.
+		CLogger::Get ()->Write (FromUSBPad8BitDoXInput, LogDebug,
+						"Waiting for receiver re-enumeration");
+		return FALSE;
+	}
+
 	if (!StartRequest()) {
 	    return FALSE;
 	}
 
 	DMA_BUFFER(u8, Response, 20);
-	int result = GetHost()->ControlMessage(
+	GetHost()->ControlMessage(
 		GetEndpoint0(),
 		REQUEST_IN | REQUEST_VENDOR | REQUEST_TO_INTERFACE,
 		0x01, 0x0100, GetInterfaceNumber(), Response, 20);

--- a/lib/usb/usbgamepad8bitdoxinput.cpp
+++ b/lib/usb/usbgamepad8bitdoxinput.cpp
@@ -1,0 +1,58 @@
+//
+// usbgamepad8bitdoxinput.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2026  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <circle/usb/usbgamepad8bitdoxinput.h>
+
+static const char FromUSBPad8BitDoXInput[] = "usbpad8bitdoxinput";
+
+CUSBGamePad8BitDoXInputDevice::CUSBGamePad8BitDoXInputDevice (CUSBFunction *pFunction)
+: CUSBGamePad8bitdoDevice (pFunction)
+{
+}
+
+CUSBGamePad8BitDoXInputDevice::~CUSBGamePad8BitDoXInputDevice (void)
+{
+}
+
+boolean CUSBGamePad8BitDoXInputDevice::Configure (void)
+{
+	if (!CUSBGamePad8bitdoDevice::Configure ())
+	{
+		return FALSE;
+	}
+
+	DMA_BUFFER(u8, Command, 3) = {0x01, 0x03, 0x02};
+	if (!SendToEndpointOut(Command, 3)) {
+		CLogger::Get ()->Write (FromUSBPad8BitDoXInput, LogError, 
+                                "Cannot initialize receiver");
+		return FALSE;
+	}
+
+	if (!StartRequest()) {
+	    return FALSE;
+	}
+
+	DMA_BUFFER(u8, Response, 20);
+	int result = GetHost()->ControlMessage(
+		GetEndpoint0(),
+		REQUEST_IN | REQUEST_VENDOR | REQUEST_TO_INTERFACE,
+		0x01, 0x0100, GetInterfaceNumber(), Response, 20);
+
+	return TRUE;
+}

--- a/lib/usb/usbgamepadxbox360pcwireless.cpp
+++ b/lib/usb/usbgamepadxbox360pcwireless.cpp
@@ -1,0 +1,255 @@
+//
+// usbgamepadxbox360pcwireless.cpp
+//
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2026  R. Stange <rsta2@o2online.de>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#include <circle/usb/usbgamepadxbox360pcwireless.h>
+#include <circle/logger.h>
+#include <circle/macros.h>
+#include <circle/util.h>
+#include <assert.h>
+
+#define XBOX360_PC_WIRELESS_REPORT_SIZE		32
+#define XBOX360_PC_WIRELESS_STATUS_SIZE		2
+#define XBOX360_PC_WIRELESS_PAYLOAD_SIZE	20
+#define XBOX360_PC_WIRELESS_STATE_SIZE	(4 + XBOX360_PC_WIRELESS_PAYLOAD_SIZE)
+
+static const char FromUSBPadXbox360PCWireless[] = "usbpadxbox360pcw";
+
+CUSBGamePadXbox360PCWirelessDevice::CUSBGamePadXbox360PCWirelessDevice (CUSBFunction *pFunction)
+: CUSBGamePadDevice (pFunction),
+	m_bInterfaceOK (SelectInterfaceByClass (0xFF, 0x5D, 0x81, 2)),
+	m_bControllerPresent (FALSE)
+{
+}
+
+CUSBGamePadXbox360PCWirelessDevice::~CUSBGamePadXbox360PCWirelessDevice (void)
+{
+}
+
+boolean CUSBGamePadXbox360PCWirelessDevice::Configure (void)
+{
+	if (!m_bInterfaceOK)
+	{
+		ConfigurationError (FromUSBPadXbox360PCWireless);
+
+		return FALSE;
+	}
+
+	m_usReportSize = XBOX360_PC_WIRELESS_REPORT_SIZE;
+	if (!CUSBGamePadDevice::Configure ())
+	{
+		CLogger::Get ()->Write (FromUSBPadXbox360PCWireless, LogError,
+					"Cannot configure wireless receiver interface");
+
+		return FALSE;
+	}
+
+	m_State.nbuttons = GAMEPAD_BUTTONS_STANDARD;
+	m_State.naxes = 6;
+	for (unsigned i = 0; i < 4; i++)
+	{
+		m_State.axes[i].minimum = GAMEPAD_AXIS_DEFAULT_MINIMUM;
+		m_State.axes[i].maximum = GAMEPAD_AXIS_DEFAULT_MAXIMUM;
+	}
+	for (unsigned i = 4; i < 6; i++)
+	{
+		m_State.axes[i].minimum = 0;
+		m_State.axes[i].maximum = 255;
+	}
+	m_State.nhats = 0;
+
+	if (!StartRequest ())
+	{
+		CLogger::Get ()->Write (FromUSBPadXbox360PCWireless, LogError,
+					"Cannot start receiver input request");
+
+		return FALSE;
+	}
+
+	if (!SendPresenceInquiry ())
+	{
+		CLogger::Get ()->Write (FromUSBPadXbox360PCWireless, LogError,
+					"Cannot query receiver controller presence");
+
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+void CUSBGamePadXbox360PCWirelessDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)
+{
+	if (pReport == 0 || nReportSize < XBOX360_PC_WIRELESS_STATUS_SIZE)
+	{
+		return;
+	}
+
+	if ((pReport[0] & 0x08) != 0)
+	{
+		boolean bControllerPresent = (pReport[1] & 0x80) != 0;
+		if (bControllerPresent != m_bControllerPresent)
+		{
+			m_bControllerPresent = bControllerPresent;
+			CLogger::Get ()->Write (FromUSBPadXbox360PCWireless, LogNotice,
+						"Controller %s", bControllerPresent ? "connected" : "disconnected");
+
+			if (bControllerPresent)
+			{
+				// Sets the top left of the green circle LED to be on, 
+				// the other three off (Xbox 360 controller player 1)
+				DMA_BUFFER (u8, Command, 12);
+				memset (Command, 0, sizeof Command);
+				Command[2] = 0x08;
+				Command[3] = 0x42;
+				SendToEndpointOutAsync (Command, sizeof Command);
+			}
+		}
+	}
+
+	if (   nReportSize < XBOX360_PC_WIRELESS_STATE_SIZE
+		|| pReport[1] != 0x01
+		|| m_pStatusHandler == 0)
+	{
+		return;
+	}
+
+	DecodeReport (pReport + 4);
+	(*m_pStatusHandler) (m_nDeviceNumber-1, &m_State);
+}
+
+void CUSBGamePadXbox360PCWirelessDevice::DecodeReport (const u8 *pReport)
+{
+	assert (pReport != 0);
+
+	static const u32 ButtonMap[] =
+	{
+		GamePadButtonUp,
+		GamePadButtonDown,
+		GamePadButtonLeft,
+		GamePadButtonRight,
+		GamePadButtonStart,
+		GamePadButtonBack,
+		GamePadButtonL3,
+		GamePadButtonR3,
+		GamePadButtonLB,
+		GamePadButtonRB,
+		GamePadButtonXbox,
+		0,
+		GamePadButtonA,
+		GamePadButtonB,
+		GamePadButtonX,
+		GamePadButtonY
+	};
+
+	u16 usButtons = pReport[2] | pReport[3] << 8;
+	m_State.buttons = 0;
+	for (unsigned i = 0; i < sizeof ButtonMap / sizeof ButtonMap[0]; i++)
+	{
+		if ((usButtons & (1 << i)) != 0)
+		{
+			m_State.buttons |= ButtonMap[i];
+		}
+	}
+
+	m_State.axes[GamePadAxisButtonLT].value = pReport[4];
+	m_State.axes[GamePadAxisButtonRT].value = pReport[5];
+	if (pReport[4] >= 128)
+	{
+		m_State.buttons |= GamePadButtonLT;
+	}
+	if (pReport[5] >= 128)
+	{
+		m_State.buttons |= GamePadButtonRT;
+	}
+
+	static const unsigned AxisMap[] =
+	{
+		GamePadAxisLeftX,
+		GamePadAxisLeftY,
+		GamePadAxisRightX,
+		GamePadAxisRightY
+	};
+
+	for (unsigned i = 0; i < sizeof AxisMap / sizeof AxisMap[0]; i++)
+	{
+		unsigned nOffset = 6 + 2*i;
+		s16 nValue = (s16) (pReport[nOffset] | pReport[nOffset+1] << 8);
+		unsigned nAxis = AxisMap[i];
+		unsigned nMappedValue = (unsigned) (nValue - (-32768)) >> 8;
+		if (   nAxis == GamePadAxisLeftY
+			|| nAxis == GamePadAxisRightY)
+		{
+			nMappedValue = GAMEPAD_AXIS_DEFAULT_MAXIMUM - nMappedValue;
+		}
+		m_State.axes[nAxis].value = nMappedValue;
+	}
+}
+
+boolean CUSBGamePadXbox360PCWirelessDevice::SendPresenceInquiry (void)
+{
+	DMA_BUFFER (u8, Command, 12);
+	memset (Command, 0, sizeof Command);
+	Command[0] = 0x08;
+	Command[2] = 0x0F;
+	Command[3] = 0xC0;
+
+	return SendToEndpointOut (Command, sizeof Command);
+}
+
+boolean CUSBGamePadXbox360PCWirelessDevice::SetLEDMode (TGamePadLEDMode Mode)
+{
+	if (Mode >= GamePadLEDModeUnknown)
+	{
+		return FALSE;
+	}
+
+	DMA_BUFFER (u8, Command, 12);
+	memset (Command, 0, sizeof Command);
+	Command[2] = 0x08;
+	Command[3] = 0x40 + Mode;
+
+	return SendToEndpointOut (Command, sizeof Command);
+}
+
+boolean CUSBGamePadXbox360PCWirelessDevice::SetRumbleMode (TGamePadRumbleMode Mode)
+{
+	DMA_BUFFER (u8, Command, 12);
+	memset (Command, 0, sizeof Command);
+	Command[1] = 0x01;
+	Command[2] = 0x0F;
+	Command[3] = 0xC0;
+
+	switch (Mode)
+	{
+	case GamePadRumbleModeOff:
+		break;
+
+	case GamePadRumbleModeLow:
+		Command[6] = 0xFF;
+		break;
+
+	case GamePadRumbleModeHigh:
+		Command[5] = 0xFF;
+		break;
+
+	default:
+		return FALSE;
+	}
+
+	return SendToEndpointOut (Command, sizeof Command);
+}

--- a/lib/usb/usbkeyboard.cpp
+++ b/lib/usb/usbkeyboard.cpp
@@ -67,7 +67,12 @@ boolean CUSBKeyboardDevice::Configure (void)
 		m_nReportSize++;
 	}
 
-	if (!CUSBHIDDevice::ConfigureHID (m_nReportSize))
+	return ConfigureKeyboard (m_nReportSize);
+}
+
+boolean CUSBKeyboardDevice::ConfigureKeyboard (unsigned nReportSize)
+{
+	if (!CUSBHIDDevice::ConfigureHID (nReportSize))
 	{
 		CLogger::Get ()->Write (FromUSBKbd, LogError, "Cannot configure HID device");
 

--- a/lib/usb/usbkeyboard8bitdo.cpp
+++ b/lib/usb/usbkeyboard8bitdo.cpp
@@ -1,7 +1,22 @@
 //
 // usbkeyboard8bitdo.cpp
 //
-
+// Circle - A C++ bare metal environment for Raspberry Pi
+// Copyright (C) 2014-2026  R. Stange <rsta2@o2online.de>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
 #include <circle/usb/usbkeyboard8bitdo.h>
 
 #define USBKEYB8BITDO_REPORT_SIZE	17

--- a/lib/usb/usbkeyboard8bitdo.cpp
+++ b/lib/usb/usbkeyboard8bitdo.cpp
@@ -56,11 +56,9 @@ void CUSBKeyboard8BitDoDevice::ReportHandler (const u8 *pReport, unsigned nRepor
 
 		for (unsigned nUsage = 0x04; nUsage <= 0x77 && nSlots < 6; nUsage++)
 		{
-			// The physical up-arrow can be reported as keypad up (0x60), so map it
-			// to the normal up-arrow usage (0x52).
 			if (pReport[2 + nUsage / 8] & (1U << (nUsage % 8)))
 			{
-				Report[2 + nSlots++] = nUsage == 0x60 ? 0x52 : nUsage;
+				Report[2 + nSlots++] = nUsage;
 			}
 		}
 

--- a/lib/usb/usbkeyboard8bitdo.cpp
+++ b/lib/usb/usbkeyboard8bitdo.cpp
@@ -1,0 +1,72 @@
+//
+// usbkeyboard8bitdo.cpp
+//
+
+#include <circle/usb/usbkeyboard8bitdo.h>
+
+#define USBKEYB8BITDO_REPORT_SIZE	17
+
+static const char FromUSBKbd8BitDo[] = "ukbd8bitdo";
+
+CUSBKeyboard8BitDoDevice::CUSBKeyboard8BitDoDevice (CUSBFunction *pFunction)
+: 	CUSBKeyboardDevice (pFunction)
+{
+}
+
+CUSBKeyboard8BitDoDevice::~CUSBKeyboard8BitDoDevice (void)
+{
+}
+
+boolean CUSBKeyboard8BitDoDevice::Configure (void)
+{
+	return ConfigureKeyboard (USBKEYB8BITDO_REPORT_SIZE);
+}
+
+void CUSBKeyboard8BitDoDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)
+{
+	// Forward HID transfer failures to the common keyboard driver.
+	if (pReport == 0)
+	{
+		CUSBKeyboardDevice::ReportHandler (0, 0);
+
+		return;
+	}
+
+	// Convert the 8BitDo NKRO bitmap report to a boot keyboard report.
+	if (   nReportSize == USBKEYB8BITDO_REPORT_SIZE
+	    && (pReport[0] == 0x0A || pReport[0] == 0x0C))
+	{
+		u8 Report[USBKEYB_REPORT_SIZE] = {pReport[1]};
+		unsigned nSlots = 0;
+
+		for (unsigned nUsage = 0x04; nUsage <= 0x77 && nSlots < 6; nUsage++)
+		{
+			// The physical up-arrow can be reported as keypad up (0x60), so map it
+			// to the normal up-arrow usage (0x52).
+			if (pReport[2 + nUsage / 8] & (1U << (nUsage % 8)))
+			{
+				Report[2 + nSlots++] = nUsage == 0x60 ? 0x52 : nUsage;
+			}
+		}
+
+		CUSBKeyboardDevice::ReportHandler (Report, sizeof Report);
+
+		return;
+	}
+
+	// Strip the report ID from a standard boot keyboard report.
+	if (nReportSize == 9 && pReport[0] == 0x01)
+	{
+		CUSBKeyboardDevice::ReportHandler (pReport + 1, USBKEYB_REPORT_SIZE);
+
+		return;
+	}
+
+	// Forward an unprefixed standard boot keyboard report.
+	if (nReportSize == USBKEYB_REPORT_SIZE)
+	{
+		CUSBKeyboardDevice::ReportHandler (pReport, nReportSize);
+
+		return;
+	}
+}

--- a/lib/usb/usbstandardhub.cpp
+++ b/lib/usb/usbstandardhub.cpp
@@ -400,7 +400,6 @@ boolean CUSBStandardHub::EnumeratePorts (void)
 		{
 			continue;
 		}
-		m_bPortConfigured[nPort] = TRUE;
 
 		if (!m_pDevice[nPort]->Configure ())
 		{
@@ -412,6 +411,9 @@ boolean CUSBStandardHub::EnumeratePorts (void)
 
 			continue;
 		}
+
+		// Leave failed configurations eligible for retry on the next scan.
+		m_bPortConfigured[nPort] = TRUE;
 		
 		CLogger::Get ()->Write (FromHub, LogDebug, "Port %u: Device configured", nPort+1);
 	}

--- a/lib/usb/usbstring.cpp
+++ b/lib/usb/usbstring.cpp
@@ -25,6 +25,7 @@
 
 #define USBSTR_MIN_LENGTH	4
 
+#define USBSTR_MAX_LENGTH	255
 #define USBSTR_DEFAULT_LANGID	0x409
 
 CUSBString::CUSBString (CUSBDevice *pDevice)
@@ -71,19 +72,31 @@ boolean CUSBString::GetFromDescriptor (u8 ucID, u16 usLanguageID)
 	assert (ucID > 0);
 
 	delete [] m_pUSBString;
-	m_pUSBString = (TUSBStringDescriptor *) new u8[USBSTR_MIN_LENGTH];
+#if RASPPI >= 4
+	const unsigned nRequestLength = USBSTR_MAX_LENGTH;
+#else
+	const unsigned nRequestLength = USBSTR_MIN_LENGTH;
+#endif
+	m_pUSBString = (TUSBStringDescriptor *) new u8[nRequestLength];
 	assert (m_pUSBString != 0);
 
 	assert (m_pDevice != 0);
-	if (m_pDevice->GetHost ()->GetDescriptor (m_pDevice->GetEndpoint0 (),
-						  DESCRIPTOR_STRING, ucID,
-						  m_pUSBString, USBSTR_MIN_LENGTH,
-						  REQUEST_IN, usLanguageID) < 0)
+	int nResult = m_pDevice->GetHost ()->GetDescriptor (m_pDevice->GetEndpoint0 (),
+							       DESCRIPTOR_STRING, ucID,
+							       m_pUSBString, nRequestLength,
+							       REQUEST_IN, usLanguageID);
+	if (nResult < 0)
 	{
 		return FALSE;
 	}
 
 	u8 ucLength = m_pUSBString->bLength;
+#if RASPPI >= 4
+	if ((unsigned) nResult < ucLength)
+	{
+		return FALSE;
+	}
+#endif
 	if (   ucLength < 2
 	    || (ucLength & 1) != 0
 	    || m_pUSBString->bDescriptorType != DESCRIPTOR_STRING)
@@ -91,7 +104,7 @@ boolean CUSBString::GetFromDescriptor (u8 ucID, u16 usLanguageID)
 		return FALSE;
 	}
 
-	if (ucLength > USBSTR_MIN_LENGTH)
+	if (ucLength > USBSTR_MIN_LENGTH && (unsigned) nResult != ucLength)
 	{
 		delete m_pUSBString;
 		m_pUSBString = (TUSBStringDescriptor *) new u8[ucLength];
@@ -118,7 +131,7 @@ boolean CUSBString::GetFromDescriptor (u8 ucID, u16 usLanguageID)
 	assert ((m_pUSBString->bLength & 1) == 0);
 	size_t nLength = (m_pUSBString->bLength-2) / 2;
 
-	assert (nLength <= (255-2) / 2);
+	assert (nLength <= (USBSTR_MAX_LENGTH-2) / 2);
 	char Buffer[nLength+1];
 	
 	for (unsigned i = 0; i < nLength; i++)
@@ -149,13 +162,19 @@ const char *CUSBString::Get (void) const
 
 u16 CUSBString::GetLanguageID (void)
 {
-	TUSBStringDescriptor *pLanguageIDs = (TUSBStringDescriptor *) new u8[USBSTR_MIN_LENGTH];
+#if RASPPI >= 4
+	const unsigned nRequestLength = USBSTR_MAX_LENGTH;
+#else
+	const unsigned nRequestLength = USBSTR_MIN_LENGTH;
+#endif
+	TUSBStringDescriptor *pLanguageIDs = (TUSBStringDescriptor *) new u8[nRequestLength];
 	assert (pLanguageIDs != 0);
 
 	assert (m_pDevice != 0);
-	if (m_pDevice->GetHost ()->GetDescriptor (m_pDevice->GetEndpoint0 (),
-						  DESCRIPTOR_STRING, 0,
-						  pLanguageIDs, USBSTR_MIN_LENGTH) < 0)
+	int nResult = m_pDevice->GetHost ()->GetDescriptor (m_pDevice->GetEndpoint0 (),
+							       DESCRIPTOR_STRING, 0,
+							       pLanguageIDs, nRequestLength);
+	if (nResult < 0)
 	{
 		delete [] pLanguageIDs;
 
@@ -163,6 +182,14 @@ u16 CUSBString::GetLanguageID (void)
 	}
 
 	u8 ucLength = pLanguageIDs->bLength;
+#if RASPPI >= 4
+	if ((unsigned) nResult < ucLength)
+	{
+		delete [] pLanguageIDs;
+
+		return USBSTR_DEFAULT_LANGID;
+	}
+#endif
 	if (   ucLength < 4
 	    || (ucLength & 1) != 0
 	    || pLanguageIDs->bDescriptorType != DESCRIPTOR_STRING)
@@ -172,7 +199,7 @@ u16 CUSBString::GetLanguageID (void)
 		return USBSTR_DEFAULT_LANGID;
 	}
 
-	if (ucLength > USBSTR_MIN_LENGTH)
+	if (ucLength > USBSTR_MIN_LENGTH && (unsigned) nResult != ucLength)
 	{
 		delete [] pLanguageIDs;
 		pLanguageIDs = (TUSBStringDescriptor *) new u8[ucLength];


### PR DESCRIPTION
- Support for 8bitdo Retro Keyboard
- Support for various 8bitdo controllers
  - Pro 3 controller needed the additional: "Set port configured after the configure call"
  - M30 2.4G controller needed: "For Pi4 pr greater devices read the entire descriptor at once."
- Support for Xbox 360 PC Wireless Receiver (and clone)

Please let me know if you need further explainations, I hope there is enough information in the code comments and commits.