### PR TITLE
Fix TheC64 keyboard handling for the two versions

### DIFF
--- a/lib/usb/usbkeyboard.cpp
+++ b/lib/usb/usbkeyboard.cpp
@@ -61,8 +61,12 @@ boolean CUSBKeyboardDevice::Configure (void)
 	// which has to be ignored.
 	const TUSBDeviceDescriptor *pDeviceDesc = GetDevice ()->GetDeviceDescriptor ();
 	assert (pDeviceDesc != 0);
+	const TUSBHIDDescriptor *pHIDDesc =
+		(const TUSBHIDDescriptor *) GetDescriptor (DESCRIPTOR_HID);
 	if (   pDeviceDesc->idVendor == 0x1C59
-	    && pDeviceDesc->idProduct == 0x99)
+	    && pDeviceDesc->idProduct == 0x99
+	    && pHIDDesc != 0
+	    && pHIDDesc->wReportDescriptorLength == 78)
 	{
 		m_nReportSize++;
 	}


### PR DESCRIPTION
Distinguish the two THEC64 keyboard firmware versions by HID report descriptor length. Only the 78-byte descriptor requires the additional report byte; the other version keeps the standard report size.

This was a problem that was reported in the BMC64 Github repo here: https://github.com/randyrossi/bmc64/issues/290 where it was discovered that there is a different revision of THEC64 keyboard that didn't work with the original patch (https://github.com/rsta2/circle/commit/4de2b0970e9ebe47987a282d17b6aa51e487c446) even though it as the same product and vendor id.

Details of my investigation and follow up are in the orignal bug reported to Circle where I contacted the orignal reporter and tested this patch with both versions of THEC64 that have been discovered. See: https://github.com/rsta2/circle/issues/531#issuecomment-5167878893 

Both parties (@Chris-Hal and @bugjacobs) reported that this fix works. 
