### PR TITLE
Fix Circle TCP ACK handling for fragmented modem sessions

### DIFF
--- a/lib/net/tcpconnection.cpp
+++ b/lib/net/tcpconnection.cpp
@@ -1230,12 +1230,6 @@ int CTCPConnection::PacketReceived (CNetBuffer	*pPacket,
 					m_bFINQueued = FALSE;
 				}
 
-				if (   m_State == TCPStateEstablished
-				    && nBytesAck == 1)
-				{
-					nBytesAck--;
-				}
-				
 				if (nBytesAck > 0)
 				{
 					m_TxQueue.Flush (nBytesAck);
@@ -1299,7 +1293,19 @@ int CTCPConnection::PacketReceived (CNetBuffer	*pPacket,
 			}
 			else if (le (nSEG_ACK, m_nSND_UNA))	// RFC 1122 section 4.2.2.20 (g)
 			{
-				OnDuplicateAck ();
+				// RFC 5681: a duplicate ACK is a pure ACK for SND.UNA,
+				// with an unchanged advertised window and data outstanding.
+				if (   nSEG_ACK == m_nSND_UNA
+				    && FLIGHT_SIZE > 0
+				    && nSEG_LEN == 0
+				    && nSEG_WND == m_nSND_WND)
+				{
+					OnDuplicateAck ();
+				}
+				else
+				{
+					m_nDupAckCount = 0;
+				}
 				
 				// RFC 1122 section 4.2.2.20 (g)
 				if (bwlh (m_nSND_UNA, nSEG_ACK, m_nSND_NXT))


### PR DESCRIPTION
I discovered this problem when implementing a software modem to use with the BMC64 project. My original commit in my fork of that project is here: https://github.com/aminch/bmc64/commit/af27ebac49ba21145fde4fe775bea498882835d3

I have only tested this on the BMC64 builds I have made. If there additional testing or test case I should run please let me know.

### Reasoning for fix

Circle left acknowledged one-byte application sends in its transmit queue while established. CCGMS commonly sends single-byte keystrokes, so later incoming ACKs could make fast retransmit send an already acknowledged byte at an old sequence number. The peer then considered subsequent fragmented data out of order, causing the session to stall or disconnect.

Flush every acknowledged application byte from the transmit queue, including one-byte sends. Restrict duplicate-ACK processing to RFC 5681 conditions: the ACK must equal SND.UNA, data must be outstanding, the segment must be ACK-only, and its advertised window must be unchanged. Reset the duplicate-ACK count for all other ACKs
