### PR TITLE
Fix synchronizationevent lost wakeup

### DIFF
--- a/include/circle/sched/scheduler.h
+++ b/include/circle/sched/scheduler.h
@@ -111,7 +111,19 @@ private:
 	void AddTask (CTask *pTask);
 	friend class CTask;
 
-	boolean BlockTask (CTask **ppWaitListHead, unsigned nMicroSeconds);
+	// aarch64pi note (2026-08-12): pState (optional, default null) closes
+	// a real lost-wakeup race - see the implementation in scheduler.cpp
+	// for the full story (confirmed via GDB on a real hang: an S3 ViRGE
+	// FIFO worker CTask left permanently Blocked on an event whose
+	// m_bState was already TRUE, because core 1's Set() ran - and found
+	// the wait list still empty - in the gap between the caller's own
+	// state check and this function's wait-list registration below,
+	// which used to be unprotected by any lock). When pState is given,
+	// *pState is re-checked under the same m_SpinLock WakeTasks()/Set()
+	// use, atomically with the registration - if already true, this
+	// returns immediately instead of blocking at all.
+	boolean BlockTask (CTask **ppWaitListHead, unsigned nMicroSeconds,
+			    const volatile boolean *pState = 0);
 	void WakeTasks (CTask **ppWaitListHead); // can be called from interrupt context
 	friend class CSynchronizationEvent;
 

--- a/include/circle/sched/scheduler.h
+++ b/include/circle/sched/scheduler.h
@@ -111,17 +111,17 @@ private:
 	void AddTask (CTask *pTask);
 	friend class CTask;
 
-	// aarch64pi note (2026-08-12): pState (optional, default null) closes
-	// a real lost-wakeup race - see the implementation in scheduler.cpp
-	// for the full story (confirmed via GDB on a real hang: an S3 ViRGE
-	// FIFO worker CTask left permanently Blocked on an event whose
-	// m_bState was already TRUE, because core 1's Set() ran - and found
-	// the wait list still empty - in the gap between the caller's own
-	// state check and this function's wait-list registration below,
-	// which used to be unprotected by any lock). When pState is given,
-	// *pState is re-checked under the same m_SpinLock WakeTasks()/Set()
-	// use, atomically with the registration - if already true, this
-	// returns immediately instead of blocking at all.
+	// pState (optional, default null) closes a real lost-wakeup race -
+	// see the implementation in scheduler.cpp for the full story
+	// (confirmed via GDB on a real hang, ARM_ALLOW_MULTI_CORE: a worker
+	// CTask left permanently Blocked on an event whose state was already
+	// true, because another core's Set() call ran - and found the wait
+	// list still empty - in the gap between the caller's own state check
+	// and this function's wait-list registration below, which used to be
+	// unprotected by any lock). When pState is given, *pState is
+	// re-checked under the same m_SpinLock WakeTasks()/Set() use,
+	// atomically with the registration - if already true, this returns
+	// immediately instead of blocking at all.
 	boolean BlockTask (CTask **ppWaitListHead, unsigned nMicroSeconds,
 			    const volatile boolean *pState = 0);
 	void WakeTasks (CTask **ppWaitListHead); // can be called from interrupt context

--- a/lib/sched/scheduler.cpp
+++ b/lib/sched/scheduler.cpp
@@ -307,7 +307,8 @@ void CScheduler::RemoveTask (CTask *pTask)
 	assert (0);
 }
 
-boolean CScheduler::BlockTask (CTask **ppWaitListHead, unsigned nMicroSeconds)
+boolean CScheduler::BlockTask (CTask **ppWaitListHead, unsigned nMicroSeconds,
+				const volatile boolean *pState)
 {
 	assert (ppWaitListHead != 0);
 	assert (m_pCurrent->m_pWaitListNext == 0);
@@ -315,6 +316,28 @@ boolean CScheduler::BlockTask (CTask **ppWaitListHead, unsigned nMicroSeconds)
 	assert (m_pCurrent->GetState () == TaskStateReady);
 
 	m_SpinLock.Acquire ();
+
+	// aarch64pi note (2026-08-12): the real fix - re-check *pState here,
+	// inside the same critical section WakeTasks()/Set() use to walk
+	// and update the wait list, instead of only in the caller
+	// (CSynchronizationEvent::Wait/WaitWithTimeout) *before* acquiring
+	// this lock. That outer check was the actual race: Set() could run
+	// between it and this function's registration below, see *this*
+	// wait list as still empty (nothing to wake), and never fire again
+	// (Set() only calls WakeTasks() once, guarded by its own
+	// if (!m_bState) - once true, a second Set() is a no-op) - while
+	// this task, having already decided to block based on the stale
+	// pre-lock check, still goes ahead and blocks anyway right after,
+	// with nothing left that will ever wake it. Returning
+	// nMicroSeconds == 0 here matches WaitWithTimeout()'s existing
+	// already-true fast path exactly (see synchronizationevent.cpp) -
+	// this is that same fast path, just moved to where it's actually
+	// race-free.
+	if (pState != 0 && *pState)
+	{
+		m_SpinLock.Release ();
+		return nMicroSeconds == 0;
+	}
 
 	// Add current task to waiting task list
 	m_pCurrent->m_pWaitListNext = *ppWaitListHead;

--- a/lib/sched/scheduler.cpp
+++ b/lib/sched/scheduler.cpp
@@ -317,22 +317,21 @@ boolean CScheduler::BlockTask (CTask **ppWaitListHead, unsigned nMicroSeconds,
 
 	m_SpinLock.Acquire ();
 
-	// aarch64pi note (2026-08-12): the real fix - re-check *pState here,
-	// inside the same critical section WakeTasks()/Set() use to walk
-	// and update the wait list, instead of only in the caller
-	// (CSynchronizationEvent::Wait/WaitWithTimeout) *before* acquiring
-	// this lock. That outer check was the actual race: Set() could run
-	// between it and this function's registration below, see *this*
-	// wait list as still empty (nothing to wake), and never fire again
-	// (Set() only calls WakeTasks() once, guarded by its own
-	// if (!m_bState) - once true, a second Set() is a no-op) - while
-	// this task, having already decided to block based on the stale
-	// pre-lock check, still goes ahead and blocks anyway right after,
-	// with nothing left that will ever wake it. Returning
-	// nMicroSeconds == 0 here matches WaitWithTimeout()'s existing
-	// already-true fast path exactly (see synchronizationevent.cpp) -
-	// this is that same fast path, just moved to where it's actually
-	// race-free.
+	// The actual fix: re-check *pState here, inside the same critical
+	// section WakeTasks()/Set() use to walk and update the wait list,
+	// instead of only in the caller (CSynchronizationEvent::Wait/
+	// WaitWithTimeout) *before* acquiring this lock. That outer check
+	// was the actual race: Set() could run between it and this
+	// function's registration below, see *this* wait list as still
+	// empty (nothing to wake), and never fire again (Set() only calls
+	// WakeTasks() once, guarded by its own if (!m_bState) - once true,
+	// a second Set() is a no-op) - while this task, having already
+	// decided to block based on the stale pre-lock check, still goes
+	// ahead and blocks anyway right after, with nothing left that will
+	// ever wake it. Returning nMicroSeconds == 0 here matches
+	// WaitWithTimeout()'s existing already-true fast path exactly (see
+	// synchronizationevent.cpp) - this is that same fast path, just
+	// moved to where it's actually race-free.
 	if (pState != 0 && *pState)
 	{
 		m_SpinLock.Release ();

--- a/lib/sched/synchronizationevent.cpp
+++ b/lib/sched/synchronizationevent.cpp
@@ -79,20 +79,25 @@ void CSynchronizationEvent::Pulse (void)
 
 void CSynchronizationEvent::Wait (void)
 {
-	if (!m_bState)
-	{
-		CScheduler::Get ()->BlockTask (&m_pWaitListHead, 0);
-	}
+	// This used to check !m_bState here, then call BlockTask()
+	// unconditionally if it looked unset - two separate, unsynchronized
+	// steps. Set() (from another core, with ARM_ALLOW_MULTI_CORE) could
+	// run in the gap between them: it would see the wait list still
+	// empty (this task hasn't registered on it yet), wake nobody, and
+	// latch its own "already fired" guard so a *later* Set() call
+	// becomes a no-op - while this task, having already decided to
+	// block based on the now-stale check, goes ahead and blocks anyway
+	// right after, with nothing left that will ever wake it.
+	//
+	// BlockTask() now takes the state pointer directly and re-checks it
+	// itself under the same lock used to walk/update the wait list -
+	// the check and the registration are one atomic operation there, so
+	// there is nothing left to check out here.
+	CScheduler::Get ()->BlockTask (&m_pWaitListHead, 0, &m_bState);
 }
 
 boolean CSynchronizationEvent::WaitWithTimeout (unsigned nMicroSeconds)
 {
-	if (m_bState)
-	{
-		return nMicroSeconds == 0;
-	}
-	else
-	{
-		return CScheduler::Get ()->BlockTask (&m_pWaitListHead, nMicroSeconds);
-	}
+	// See the comment in Wait() above - same fix, same reasoning.
+	return CScheduler::Get ()->BlockTask (&m_pWaitListHead, nMicroSeconds, &m_bState);
 }


### PR DESCRIPTION
Hello René,

I'm making a version of 86Box that can run on baremetal. That project is an heavy multi core and multi-CTask thing and exposed a real problem because it has a concurrent emulation on core 1 and seven CTask on core 0.

Wait()/WaitWithTimeout() check m_bState, then call BlockTask() to actually block - two separate steps, not atomic. Under ARM_ALLOW_MULTI_CORE, another core's Set() can land in the gap between them: it sees the wait list still empty, wakes nobody, and marks itself already-fired (so a later Set() is a no-op) - while the waiter, having already decided to block from the now-stale check, blocks anyway right after with nothing left to ever wake it.

Found this via GDB on a real hang: a worker CTask stuck Blocked forever on an event that was already TRUE, with real pending work behind it nobody would process.

Fix: BlockTask() takes an optional state pointer and re-checks it itself, under the same lock Set()/WakeTasks() use so the check and the registration become one atomic step instead of two.

Tested on a Pi Zero 2, I'll test this on a Pi 4 soon