### PR TITLE
Don't use blocking USB bulk-IN receives when ethernet link is down

### DIFF
--- a/include/circle/usb/lan7800.h
+++ b/include/circle/usb/lan7800.h
@@ -45,6 +45,7 @@ public:
 
 	// returns TRUE if PHY link is up
 	boolean IsLinkUp (void);
+	boolean UpdatePHY (void);
 	
 	TNetDeviceSpeed GetLinkSpeed (void);
 
@@ -75,6 +76,7 @@ private:
 	CMACAddress m_MACAddress;
 
 	u32 m_FilterTable[33][2];
+	volatile boolean m_bLinkUp;
 };
 
 #endif

--- a/include/circle/usb/smsc951x.h
+++ b/include/circle/usb/smsc951x.h
@@ -44,6 +44,7 @@ public:
 	
 	// returns TRUE if PHY link is up
 	boolean IsLinkUp (void);
+	boolean UpdatePHY (void);
 
 	TNetDeviceSpeed GetLinkSpeed (void);
 
@@ -69,6 +70,7 @@ private:
 	CUSBEndpoint *m_pEndpointBulkOut;
 
 	CMACAddress m_MACAddress;
+	volatile boolean m_bLinkUp;
 };
 
 #endif

--- a/lib/usb/lan7800.cpp
+++ b/lib/usb/lan7800.cpp
@@ -232,7 +232,8 @@ static const char FromLAN7800[] = "lan7800";
 CLAN7800Device::CLAN7800Device (CUSBFunction *pFunction)
 :	CUSBFunction (pFunction),
 	m_pEndpointBulkIn (0),
-	m_pEndpointBulkOut (0)
+	m_pEndpointBulkOut (0),
+	m_bLinkUp (FALSE)
 {
 }
 
@@ -445,6 +446,11 @@ boolean CLAN7800Device::SendFrame (const void *pBuffer, unsigned nLength)
 
 boolean CLAN7800Device::ReceiveFrame (void *pBuffer, unsigned *pResultLength)
 {
+	if (!m_bLinkUp)
+	{
+		return FALSE;
+	}
+
 	assert (m_pEndpointBulkIn != 0);
 	assert (pBuffer != 0);
 	CUSBRequest URB (m_pEndpointBulkIn, pBuffer, FRAME_BUFFER_SIZE);
@@ -489,13 +495,20 @@ boolean CLAN7800Device::ReceiveFrame (void *pBuffer, unsigned *pResultLength)
 
 boolean CLAN7800Device::IsLinkUp (void)
 {
+	return m_bLinkUp;
+}
+
+boolean CLAN7800Device::UpdatePHY (void)
+{
 	u16 usPHYModeStatus;
 	if (!PHYRead (0x01, &usPHYModeStatus))
 	{
-		return FALSE;
+		return TRUE;
 	}
 
-	return usPHYModeStatus & (1 << 2) ? TRUE : FALSE;
+	m_bLinkUp = usPHYModeStatus & (1 << 2) ? TRUE : FALSE;
+
+	return TRUE;
 }
 
 TNetDeviceSpeed CLAN7800Device::GetLinkSpeed (void)

--- a/lib/usb/smsc951x.cpp
+++ b/lib/usb/smsc951x.cpp
@@ -130,7 +130,8 @@ static const char FromSMSC951x[] = "smsc951x";
 CSMSC951xDevice::CSMSC951xDevice (CUSBFunction *pFunction)
 :	CUSBFunction (pFunction),
 	m_pEndpointBulkIn (0),
-	m_pEndpointBulkOut (0)
+	m_pEndpointBulkOut (0),
+	m_bLinkUp (FALSE)
 {
 }
 
@@ -274,6 +275,11 @@ boolean CSMSC951xDevice::SendFrame (const void *pBuffer, unsigned nLength)
 
 boolean CSMSC951xDevice::ReceiveFrame (void *pBuffer, unsigned *pResultLength)
 {
+	if (!m_bLinkUp)
+	{
+		return FALSE;
+	}
+
 	assert (m_pEndpointBulkIn != 0);
 	assert (pBuffer != 0);
 	CUSBRequest URB (m_pEndpointBulkIn, pBuffer, FRAME_BUFFER_SIZE);
@@ -318,13 +324,20 @@ boolean CSMSC951xDevice::ReceiveFrame (void *pBuffer, unsigned *pResultLength)
 
 boolean CSMSC951xDevice::IsLinkUp (void)
 {
+	return m_bLinkUp;
+}
+
+boolean CSMSC951xDevice::UpdatePHY (void)
+{
 	u16 usPHYModeStatus;
 	if (!PHYRead (0x01, &usPHYModeStatus))
 	{
-		return FALSE;
+		return TRUE;
 	}
 
-	return usPHYModeStatus & (1 << 2) ? TRUE : FALSE;
+	m_bLinkUp = usPHYModeStatus & (1 << 2) ? TRUE : FALSE;
+
+	return TRUE;
 }
 
 TNetDeviceSpeed CSMSC951xDevice::GetLinkSpeed (void)


### PR DESCRIPTION
Another fix while developing BMC64.

Fix emulator BMC64 slow downs while Ethernet link is down

BMC64 starts networking asynchronously so emulation can launch before Ethernet has a physical link or DHCP address. Circle then runs its network task in the background and repeatedly polls the selected network device.

The LAN7800 and SMSC951x drivers used blocking USB bulk-IN receives even when the PHY reported no link. With the cable unplugged, this could leave the network task waiting indefinitely and cause severe emulation, video, and audio slowdowns.

Fixed by tracking PHY link state through Circle's periodic PHY task and skip receive submissions while the link is down. This covers SMSC951x on Pi 2/Pi 3B and LAN7800 on Pi 3B+.

The original patch in BMC64 can be see here: https://github.com/randyrossi/bmc64/commit/c506c424692c0b104d290de568c39ad95c2a1ad2

FYI: @randyrossi here is the ethernet patch submission.
