### PR TITLE
circle-stdlib returns to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This release offers a significantly improved implementation of the TCP/IP networ
 
 The socket API is nearly unchanged, but the new `MSG_MORE` flag can be specified, when calling `CSocket::Send()` on TCP sockets, which prevents the immediate delivery of received data on the receiver side, when more data follows. `CSocket::Bind()` can be called with port 0 to bind to an ephemeral port, which can be requested using `CSocket::GetOwnPort()`. `CSocket::SendTo()` without preceding `Bind()` or `Connect()` is allowed too, which automatically assigns an ephemeral port.
 
-Circle supports the extended C++ standard library support (LLVM libc++ port) in the [circle-stdlib](https://codeberg.org/larchcone/circle-stdlib) project in several ways (e.g. with the new `STDLIB_SUPPORT=4` level).
+Circle supports the extended C++ standard library support (LLVM libc++ port) in the [circle-stdlib](https://github.com/smuehlst/circle-stdlib) project in several ways (e.g. with the new `STDLIB_SUPPORT=4` level).
 
 The recommended toolchain to build Circle applications is now based on GCC 15.2.Rel1. See the link in the Build section! Circle is built with `-std=c++17` by default now. There are options for selecting C++14 (previous default) and C++20 for the `configure` tool, beside the new `--kernel-max-size`, `--clang` and `--kasan` options. Enter `./configure --help` for more info!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This document gives some information for Circle users, who want to help developi
 
 If you encounter a problem or want a new feature in Circle, you can create a new issue [here](https://github.com/rsta2/circle/issues). Before you do so, please check, if the same issue has been created by another user yet. You can use the search function to accomplish this. Some basic known issues have been reported [here](doc/issues.txt). Please check them too.
 
-Please take a moment to think about, if your request is not related more to the [circle-stdlib project](https://codeberg.org/larchcone/circle-stdlib), if you are using it together with Circle. If so, please create your issue there.
+Please take a moment to think about, if your request is not related more to the [circle-stdlib project](https://github.com/smuehlst/circle-stdlib), if you are using it together with Circle. If so, please create your issue there.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This release offers a significantly improved implementation of the TCP/IP networ
 
 The socket API is nearly unchanged, but the new `MSG_MORE` flag can be specified, when calling `CSocket::Send()` on TCP sockets, which prevents the immediate delivery of received data on the receiver side, when more data follows. `CSocket::Bind()` can be called with port 0 to bind to an ephemeral port, which can be requested using `CSocket::GetOwnPort()`. `CSocket::SendTo()` without preceding `Bind()` or `Connect()` is allowed too, which automatically assigns an ephemeral port.
 
-Circle supports the extended C++ standard library support (LLVM libc++ port) in the [circle-stdlib](https://codeberg.org/larchcone/circle-stdlib) project in several ways (e.g. with the new `STDLIB_SUPPORT=4` level).
+Circle supports the extended C++ standard library support (LLVM libc++ port) in the [circle-stdlib](https://github.com/smuehlst/circle-stdlib) project in several ways (e.g. with the new `STDLIB_SUPPORT=4` level).
 
 The recommended toolchain to build Circle applications is now based on GCC 15.2.Rel1. See the link in the Build section! Circle is built with `-std=c++17` by default now. There are options for selecting C++14 (previous default) and C++20 for the `configure` tool, beside the new `--kernel-max-size`, `--clang` and `--kasan` options. Enter `./configure --help` for more info!
 

--- a/doc/issues.txt
+++ b/doc/issues.txt
@@ -26,7 +26,7 @@ Known issues of Circle are:
 * sample/31-webclient does not work any more, because of the missing SSL/TLS
   support. SSL/TLS support for Circle is developed here:
 
-	https://codeberg.org/larchcone/circle-stdlib
+	https://github.com/smuehlst/circle-stdlib
 
 * Some modules in the addon/ subdirectory will not build with STDLIB_SUPPORT = 0.
 

--- a/doc/qemu.txt
+++ b/doc/qemu.txt
@@ -8,11 +8,11 @@ it provides USB and TCP/IP networking support. For running Circle applications
 with TCP/IP networking in QEMU is still a patch needed, which is provided in
 this repository (commit 62b39b2):
 
-	https://codeberg.org/larchcone/qemu
+	https://github.com/smuehlst/qemu
 
 To get and build the QEMU source code for Circle enter the following commands:
 
-	git clone https://codeberg.org/larchcone/qemu.git	# with patch
+	git clone https://github.com/smuehlst/qemu.git		# with patch
 	git clone https://gitlab.com/qemu-project/qemu.git	# or latest version
 
 	cd qemu

--- a/doc/stdlib-support.txt
+++ b/doc/stdlib-support.txt
@@ -16,7 +16,7 @@ options STDLIB_SUPPORT=2, STDLIB_SUPPORT=3 and STDLIB_SUPPORT=4. This is mainly
 realized by the following project (newlib and libc++ ports for Circle) by
 Stephan Muehlstrasser:
 
-	https://codeberg.org/larchcone/circle-stdlib
+	https://github.com/smuehlst/circle-stdlib
 
 Circle is included as a Git sub-module into this project, which provides a configure
 script and makefiles to build all required libraries (including the

--- a/sample/31-webclient/README
+++ b/sample/31-webclient/README
@@ -5,7 +5,7 @@ now, which is not supported by Circle itself. But there is SSL/TLS support in
 the circle-stdlib project of Stephan Muehlstrasser soon. If you are interested
 in this, have a look at:
 
-	https://codeberg.org/larchcone/circle-stdlib
+	https://github.com/smuehlst/circle-stdlib
 
 This sample has been ported to SSL/TLS support in the referenced project, but is
 retained here, because it shows how to communicate with HTTP servers.


### PR DESCRIPTION
Restored the GitHub links for circle-stdlib, as it migrates from Codeberg back to GitHub because of Codeberg's new policy regarding software developed with AI assistance.
