### PR TITLE
CUSBDeviceFactory: try CUSBMouseDevice for generic HID mouse

### DIFF
--- a/lib/usb/usbdevicefactory.cpp
+++ b/lib/usb/usbdevicefactory.cpp
@@ -303,8 +303,10 @@ CUSBFunction *CUSBDeviceFactory::GetGenericHIDDevice (CUSBFunction *pParent)
 		return 0;
 	}
 
-	// If we find a Usage Page (Digitizer) item anywhere in the HID report descriptor,
-	// then use the touch screen driver, otherwise the gamepad standard driver.
+	// If we find a Usage Page (Digitizer) item, use the touch screen driver.
+	// Same idea for a Usage Page (Generic Desktop) + Usage (Mouse) pair: try
+	// CUSBMouseDevice before falling back to the gamepad driver.
+	boolean bSawGenericDesktopPage = FALSE;
 	const u8 *pDesc = ReportDescriptor;
 	for (u16 nDescSize = usReportDescriptorLength; nDescSize;)
 	{
@@ -346,6 +348,19 @@ CUSBFunction *CUSBDeviceFactory::GetGenericHIDDevice (CUSBFunction *pParent)
 		{
 			return new CUSBTouchScreenDevice (pParent);
 		}
+
+#ifndef EXCLUDE_USB_MOUSE
+		if (ucItem == 0x04)		// Usage Page
+		{
+			bSawGenericDesktopPage = (nArg == 0x01);	// Generic Desktop
+		}
+		else if (   ucItem == 0x08	// Usage
+			 && nArg == 0x02	// Mouse
+			 && bSawGenericDesktopPage)
+		{
+			return new CUSBMouseDevice (pParent);
+		}
+#endif
 	}
 #endif
 


### PR DESCRIPTION
Hello Rene,

still on my 86box project, this time I got a very generic mini keyboard with a touchpad from Aliexpress.
The keyboard worked perfectly, the touchpad no, so I took an hexdump of the device descriptor and debugged a little.

GetGenericHIDDevice() already looks for a Digitizer usage page before falling back to the gamepad driver. Do the same for mice: if the descriptor has a Generic Desktop usage page followed by a Mouse usage, try CUSBMouseDevice first. This covers devices that never declare boot protocol support at the USB interface level even though their actual report is an ordinary relative mouse.
My touchpad interface reports subclass and protocol as zero, so it always fell through to the gamepad driver, which has no idea what to do with relative axes.

Tested on a Raspberry Pi 4 with a SINO WEALTH USB touchpad keyboard, works correctly now.

And this time I hope to have selected the right branch...

Cheers,
Valerio
