### PR TITLE
Fix Wifi unable to connect to eero7 router

### DIFF
--- a/addon/wlan/ether4330.c
+++ b/addon/wlan/ether4330.c
@@ -2384,8 +2384,11 @@ setauth(Ctlr *ctlr, Cmdbuf *cb, char *a)
 	uchar wpaie[32];
 	int i;
 
-	i = parsehex((char*)wpaie, sizeof wpaie, a);
-	if(i < 2 || i != wpaie[1] + 2)
+	i = parsehex((char*)wpaie, 2, a);
+	if(i != 2 || wpaie[1] > sizeof wpaie - 2)
+		cmderror(cb, "bad wpa ie syntax");
+	i = parsehex((char*)wpaie, wpaie[1] + 2, a);
+	if(i != wpaie[1] + 2)
 		cmderror(cb, "bad wpa ie syntax");
 	if(wpaie[0] == 0xdd)
 		ctlr->cryptotype = Wpa;


### PR DESCRIPTION
Association request failed with "bad wpa ie syntax" due to an optional IE trailing the RSN/WPA2 IE. Optional IE now ignored. 

Detailed analysis here: https://github.com/randyrossi/bmc64/issues/335

The user with the problem confirmed it is fixed, and existing users seem unaffected.  I only have so many Wi-Fi routers I can test.
