### PR TITLE
usbkeyboard8bitdo: Fix LED status reports

### DIFF
--- a/include/circle/usb/usbkeyboard.h
+++ b/include/circle/usb/usbkeyboard.h
@@ -60,7 +60,7 @@ public:
 	void UnregisterKeyStatusHandlerRaw (void);
 
 	// works in cooked and raw mode
-	boolean SetLEDs (u8 ucStatus);		// must not be called in interrupt context
+	virtual boolean SetLEDs (u8 ucStatus);		// must not be called in interrupt context
 
 
 protected:

--- a/include/circle/usb/usbkeyboard8bitdo.h
+++ b/include/circle/usb/usbkeyboard8bitdo.h
@@ -29,6 +29,7 @@ public:
 	~CUSBKeyboard8BitDoDevice (void);
 
 	boolean Configure (void);
+	boolean SetLEDs (u8 ucStatus);		// this device expects report ID 1, not the default 0
 
 protected:
 	void ReportHandler (const u8 *pReport, unsigned nReportSize);

--- a/lib/usb/usbkeyboard8bitdo.cpp
+++ b/lib/usb/usbkeyboard8bitdo.cpp
@@ -18,8 +18,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 #include <circle/usb/usbkeyboard8bitdo.h>
+#include <circle/synchronize.h>
 
 #define USBKEYB8BITDO_REPORT_SIZE	17
+#define USBKEYB8BITDO_REPORT_ID	1
+
+static const char FromUSBKbd8BitDo[] = "ukbd8bitdo";
 
 CUSBKeyboard8BitDoDevice::CUSBKeyboard8BitDoDevice (CUSBFunction *pFunction)
 : 	CUSBKeyboardDevice (pFunction)
@@ -33,6 +37,18 @@ CUSBKeyboard8BitDoDevice::~CUSBKeyboard8BitDoDevice (void)
 boolean CUSBKeyboard8BitDoDevice::Configure (void)
 {
 	return ConfigureKeyboard (USBKEYB8BITDO_REPORT_SIZE);
+}
+
+// This device's Output (LED) report needs Report ID 1, not the default 0.
+boolean CUSBKeyboard8BitDoDevice::SetLEDs (u8 ucStatus)
+{
+	DMA_BUFFER (u8, Buffer, 2) = {USBKEYB8BITDO_REPORT_ID, ucStatus};
+
+	return GetHost ()->ControlMessage (GetEndpoint0 (),
+					   REQUEST_OUT | REQUEST_CLASS | REQUEST_TO_INTERFACE,
+					   SET_REPORT,
+					   (REPORT_TYPE_OUTPUT << 8) | USBKEYB8BITDO_REPORT_ID,
+					   GetInterfaceNumber (), Buffer, 2) >= 0;
 }
 
 void CUSBKeyboard8BitDoDevice::ReportHandler (const u8 *pReport, unsigned nReportSize)

--- a/lib/usb/usbkeyboard8bitdo.cpp
+++ b/lib/usb/usbkeyboard8bitdo.cpp
@@ -23,8 +23,6 @@
 #define USBKEYB8BITDO_REPORT_SIZE	17
 #define USBKEYB8BITDO_REPORT_ID	1
 
-static const char FromUSBKbd8BitDo[] = "ukbd8bitdo";
-
 CUSBKeyboard8BitDoDevice::CUSBKeyboard8BitDoDevice (CUSBFunction *pFunction)
 : 	CUSBKeyboardDevice (pFunction)
 {


### PR DESCRIPTION
CUSBKeyboard8BitDoDevice did not override SetLEDs(), so the base
class implementation was always used, sending LED output reports
with report ID 0. This device expects report ID 1, so caps lock,
num lock and scroll lock LEDs never illuminated.

Add the SetLEDs() override that prefixes the report with ID 1,
and mark CUSBKeyboardDevice::SetLEDs() virtual so it dispatches
correctly.

Small addtion to my original pull request: https://github.com/rsta2/circle/pull/685