### PR TITLE
Fix out-of-bounds write on DWHCI exhaustion

### DIFF
--- a/lib/usb/dwhcidevice.cpp
+++ b/lib/usb/dwhcidevice.cpp
@@ -1504,6 +1504,18 @@ void CDWHCIDevice::SOFInterruptHandler (void)
 		unsigned nChannel = AllocateChannel ();
 		assert (nChannel < m_nChannels);	// too many parallel transactions otherwise
 
+		if (nChannel >= m_nChannels)
+		{
+			// No free channel this SOF. The assert() above is
+			// compiled out in release builds, so nChannel (== m_nChannels,
+			// out of range) was used as an array index anyway - silent
+			// out-of-bounds write into m_pStageData[]. Re-queue for the
+			// next frame instead.
+			QueueTransaction (pStageData);
+
+			break;
+		}
+
 		pStageData->SetChannelNumber (nChannel);
 
 		assert (m_pStageData[nChannel] == 0);


### PR DESCRIPTION
Found while debugging a composite device with 6 concurrently polled HID interfaces. SOFInterruptHandler() used an out-of-range channel index when none were free; the guarding assert() is compiled out in release builds, so it silently corrupted memory past the end of m_pStageData[] instead of failing safely. Re-queue the transaction for the next frame instead.

This was found when attempting to fix support for Keyrah in BMC64: https://github.com/randyrossi/bmc64/issues/235#issuecomment-5646932517

I am not sure what other specific testing should be done to check this further. Please let me know if you need more details.